### PR TITLE
v2: enforced, not requested - gates, runnable checks, Stop hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.0.0 (2026-08-10)
+
+Enforcement moved from prose into files, checks and an optional hook. Motivated by a controlled six-run test of v1 (two build tasks, three conditions each, independent code review plus adversarial verification plus live browser testing) whose headline results are in the README.
+
+Breaking change to the method's semantics:
+
+- The Depth Tree is now a decomposition tool, not an effort multiplier. Measured runs ignored the 2^(N-1) arithmetic (tree 6 cost about 1.0-1.5x tree 3). Depth now follows the task's natural joints; effort per leaf is enforced by that leaf's gates.
+
+New:
+
+- **Rule zero: gates before work.** Acceptance criteria go into `GATES.md` / `gates/*.md` as checkboxes with runnable `CHECK:` / `EXPECT:` lines and mandatory evidence. Done means the ledger is full, not that the output feels finished.
+- **`scripts/gate-check.mjs`**: runs CHECK commands, flips boxes only on EXPECT match, records capped evidence, treats checked-without-evidence as unmet. Zero dependencies, Node 16+.
+- **`scripts/stop-hook.mjs`** (Claude Code, optional): Stop hook that blocks ending the turn while gates are unmet. Progress-aware loop guard: counter resets when gate files change, releases with a warning after 6 blocked stops without progress, honors `ABANDON: <gate> <reason>` as an honest exit.
+- **`scripts/install-hooks.mjs`**: idempotent install/uninstall into project `settings.local.json` (default), shared `settings.json` (`--shared`) or `~/.claude/settings.json` (`--global`).
+- **Orchestrated mode** for tree 4+: `PLAN.md` contract fixed before fan-out, one gates file per leaf and per branch, leaves run as fresh subagents, parent re-runs each leaf's checks (self-certification counts for nothing). Templates in `templates/`.
+- **Report audit rule**: every number in a final report is re-measured at report time or labeled unverified. In testing, wrong numbers in confident reports were the single most reproducible failure that survived v1.
+- **Token economy** guidance, measured: checks as subprocesses instead of model re-reading, capped evidence, lean leaf briefs, append-only status logs, model tiering for mechanical leaves.
+- References split out for progressive disclosure: `references/method.md`, `references/gates.md`, `references/orchestration.md`, `references/token-economy.md`.
+
+Kept from v1: the four work passes, contracts before fan-out, continuation forcing (now mechanical: run gate-check, refute one passed gate), finish one line of attack, do not simulate work you can do, resource-anxiety rule (now with a concrete handover path), full-sweep counting.
+
 ## 1.0.0 (2026-08-10)
 
 Initial release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for wanting to improve unlazy. It is a small project on purpose: one skill file, one README. Contributions that keep it small are the easiest to merge.
+Thanks for wanting to improve unlazy. It is a small project on purpose: one skill file, a few references and three zero-dependency scripts. Contributions that keep it small are the easiest to merge.
 
 ## What is welcome
 
@@ -11,11 +11,13 @@ Thanks for wanting to improve unlazy. It is a small project on purpose: one skil
 
 ## Ground rules
 
-1. **The Depth Tree semantics are fixed.** Estimate T once at the root, binary split, every leaf gets the full T, no per-leaf re-estimation. PRs that weaken the multiplication will be declined; that rule is the project.
-2. **Claims need sources.** Behavioral claims about models must cite research from roughly the last two years. No folklore.
-3. **No em dashes, no en dashes.** House style. Use hyphens, colons or sentence breaks.
-4. **Frontmatter stays spec-compliant.** `name` and `description` follow the agent skills format so every supported tool keeps parsing it.
+1. **Enforcement stays structural.** The v2 core rule: done is proven against gates files with runnable checks and evidence, never asserted in prose. PRs that move enforcement back into promises will be declined; that hierarchy is the project.
+2. **The gate file format is a contract.** `gate-check.mjs` and `stop-hook.mjs` parse the format specified in `references/gates.md`. Format changes must update both scripts, the spec, and the templates in the same PR.
+3. **Claims need sources.** Behavioral claims about models must cite research from roughly the last two years, or a reproducible measurement like the six-run test in the README. No folklore.
+4. **No em dashes, no en dashes.** House style. Use hyphens, colons or sentence breaks.
+5. **Frontmatter stays spec-compliant.** `name` and `description` follow the agent skills format so every supported tool keeps parsing it.
+6. **Scripts stay zero-dependency.** Node 16+ standard library only, Windows and POSIX both.
 
 ## How
 
-Open an issue for anything debatable, or a PR directly for anything obvious. There is no build step and no test suite: the review is a human reading the diff.
+Open an issue for anything debatable, or a PR directly for anything obvious. There is no build step. For script changes, exercise every path by hand: a gates file with a passing check, a failing check, a regex EXPECT, a manual gate, and an ABANDON line; plus the hook's block, release-after-6, progress-reset and no-gates paths, and the installer's install, idempotence and uninstall round trip.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 # unlazy
 
-**An anti-laziness skill for AI agents.**
-Built around the Depth Tree method: split the task N layers deep,
-then give every leaf the full time budget of the whole task.
+**An anti-laziness skill for AI agents. v2: enforced, not requested.**
 
-Effort multiplies with depth. It never divides.
+v1 told the model to work harder. v2 makes half-done structurally visible:
+acceptance gates live in files, checks run as commands, and an optional hook
+blocks the agent from declaring victory while gates are unmet.
+
+You do not promise you are done. You prove it against a ledger.
 
 Works with Claude Code, OpenAI Codex, Cursor and anything else that reads `SKILL.md`.
+Hard enforcement (the Stop hook) is Claude Code only; everything else is plain markdown and Node.
 
-[Use it](#use-it) · [The problem](#the-problem-model-laziness-is-real-and-measured) · [The method](#the-depth-tree-method) · [Research](#the-research) · [Contributing](#contributing)
+[Use it](#use-it) · [What changed in v2](#what-changed-in-v2-and-why) · [How it works](#how-it-works) · [The method](#the-depth-tree-v2) · [Costs](#what-it-costs) · [Research](#the-research)
 
 </div>
 
@@ -25,10 +28,10 @@ Install once, then invoke it in plain language. The skill also triggers on its o
 ```
 
 ```
-tree 4 this bug hunt and do not stop until it is done
+tree 3 build the landing page and do not stop until every gate is checked
 ```
 
-`tree N` means: split the task N layers deep, and every leaf at the bottom gets the full time budget of the whole task. `tree 3` is 4 units of work, `tree 5` is 16, `tree 7` is 64. Pick the depth by how badly you want it done.
+`tree N` picks how deep the task gets decomposed. Leaves are units of real work, each finished against its own gates. `tree 2-3` for a feature or bug hunt, `tree 4-5` for a subsystem, `tree 6-7` for a whole project built leaf by leaf with fresh-context subagents.
 
 ### Install
 
@@ -52,7 +55,19 @@ git clone https://github.com/Leonxlnx/unlazy ~/.claude/skills/unlazy
 git clone https://github.com/Leonxlnx/unlazy ~/.codex/skills/unlazy
 ```
 
-**Everything else:** [SKILL.md](SKILL.md) is a plain markdown file. Paste it as a system prompt, a Cursor rule, or a preamble. The method is model-agnostic.
+**Everything else:** [SKILL.md](SKILL.md) is a plain markdown file. Paste it as a system prompt, a Cursor rule, or a preamble. Gates and scripts need only Node 16+.
+
+### Hard mode (Claude Code, optional)
+
+The skill works everywhere as discipline. In Claude Code it can also work as a wall: a Stop hook that structurally blocks ending the turn while gates are unmet.
+
+```bash
+node <path-to-skill>/scripts/install-hooks.mjs            # this project only (settings.local.json)
+node <path-to-skill>/scripts/install-hooks.mjs --global   # every project
+node <path-to-skill>/scripts/install-hooks.mjs --uninstall
+```
+
+It is a millisecond file scan, zero tokens per check. If the agent makes no gate progress across six consecutive blocked stops, the hook releases it with a warning instead of trapping it, and an `ABANDON: <gate> <reason>` line is always honored as an honest exit. Add `.unlazy-hook-state.json` to your `.gitignore`.
 
 ### Or let your agent install it
 
@@ -72,6 +87,92 @@ skill's description. Do not tell me it is installed unless you have actually
 verified the file is on disk.
 ```
 
+## What changed in v2, and why
+
+v1 was instructions. To find out what instructions actually buy, the method was put through a controlled test: two build-from-scratch tasks (a marketing site and a three.js solar system), three conditions each (no skill, tree 3, tree 6), one fresh folder and fresh session per run, same model, same prompt body. Every output was code-reviewed by independent agents, adversarially re-verified, and live-tested in a browser.
+
+What the test found, in five lines:
+
+| Finding | Consequence for v2 |
+|---|---|
+| Baseline already ships zero placeholders, zero console errors | The banned-list was fighting a solved problem; v2 aims at what actually failed |
+| The skill raised effort 1.6-3.9x and fixed 4-10 self-found defects pre-delivery | The passes and gates discipline demonstrably work; they stay |
+| tree 6 cost about 1.0-1.5x tree 3, never the promised 8x | The 2^(N-1) arithmetic was fiction; depth is now decomposition, not multiplication |
+| The only hard live failure was a baseline build, and its report claimed the case was handled | Claims need runnable checks, not confidence; hence CHECK/EXPECT gates |
+| Every skill run's final report contained 1-3 wrong numbers; baselines had zero | Hence the report audit rule: re-measure every number at report time |
+
+The deeper lesson: prose cannot enforce prose. A model that under-executes instructions also under-executes the instruction not to under-execute. So v2 moves enforcement down a hierarchy, each layer catching what the one above misses:
+
+1. **Discipline** (SKILL.md): weakest layer, works in any agent.
+2. **Gates files** (`GATES.md`, `gates/*.md`): intentions written at minute 2 stay sharp at minute 90.
+3. **Runnable checks** (`scripts/gate-check.mjs`): a CHECK command decides, not a feeling of completion.
+4. **Parent re-verification** (orchestrated mode): the dispatcher re-runs each leaf's checks; self-certification is worthless.
+5. **The Stop hook** (`scripts/stop-hook.mjs`): ending the turn with unmet gates is blocked, mechanically.
+
+## How it works
+
+Before real work starts, the agent writes its acceptance gates to a file:
+
+```markdown
+# Gates: pricing section
+
+- [ ] G1: three tiers render with real copy
+  CHECK: node check.js pricing --tiers
+  EXPECT: 3/3 tiers ok
+  EVIDENCE: pending
+
+- [ ] G2: annual toggle changes both price and label
+  CHECK: node check.js pricing --toggle
+  EXPECT: toggle ok
+  EVIDENCE: pending
+```
+
+`gate-check.mjs` runs the CHECK commands, flips boxes only when EXPECT matches, and records the deciding output lines as evidence. A checked box whose evidence still reads `pending` counts as unmet; a checkbox is a claim, evidence is the proof. Done means the ledger is full, and the final report pastes it, N of N, with every number re-measured at report time.
+
+For big builds (tree 4+), the tree becomes a real plan: `PLAN.md` holds the contract (interfaces, file ownership, naming, fixed before fan-out), every leaf and branch gets its own gates file, and each leaf runs as a fresh subagent. Fresh context per leaf is the point: the stall-at-80-percent failure is an end-of-long-context disease, and attention, not time, was always the scarce resource.
+
+## The Depth Tree, v2
+
+Created by [Leonxlnx](https://github.com/Leonxlnx).
+
+1. **Split at natural joints, N layers deep.** Leaves are where work happens; branches are decomposition and integration.
+2. **A leaf is a real unit of work**: ten or more minutes, one deliverable, one gates file. Smaller leaves mean you went too deep.
+3. **Contracts before fan-out.** Interfaces and file ownership are fixed in PLAN.md before any leaf starts.
+4. **Branches get integration gates.** Thirty-two locally perfect leaves can still be a broken product; branch gates catch exactly that.
+5. **Effort per leaf comes from its gates.** Finished means every box checked with evidence and an improvement pass that finds nothing, whichever is later.
+
+Full method: [references/method.md](references/method.md) · gate format spec: [references/gates.md](references/gates.md) · orchestration: [references/orchestration.md](references/orchestration.md)
+
+## What it costs
+
+Measured, not guessed (details in [references/token-economy.md](references/token-economy.md)):
+
+- Discipline alone (solo mode, gates file, no hook) costs a few hundred tokens of overhead and roughly 1.5-4x baseline output on tasks the model would otherwise treat lightly. That multiple bought committed design, robustness sweeps and pre-delivery bug hunts in testing.
+- The hook costs zero tokens; it is a file scan.
+- Orchestrated mode multiplies cost with leaf count, deliberately, and is worth it only for real builds. Below roughly half an hour of work, stay solo.
+- Checks-as-commands is the quiet saver: every CHECK line replaces thousands of tokens of the model re-reading its own work with a free subprocess.
+
+## What is in the repo
+
+```
+SKILL.md                       the skill: rule zero, modes, tree v2, report audit
+references/
+  method.md                    the Depth Tree v2 in full
+  gates.md                     gate file format spec and writing guide
+  orchestration.md             leaves as fresh agents, verification hierarchy
+  token-economy.md             cost discipline, measured
+templates/
+  PLAN.md                      contract + tree + append-only status log
+  gates-leaf.md                per-leaf gates
+  gates-node.md                per-branch integration gates
+scripts/
+  gate-check.mjs               runs CHECK commands, flips boxes, records evidence
+  stop-hook.mjs                Claude Code Stop hook: blocks stop while gates unmet
+  install-hooks.mjs            idempotent hook install/uninstall
+```
+
+All scripts are zero-dependency Node 16+, tested on Windows and POSIX shells.
+
 ## The problem: model laziness is real and measured
 
 "Laziness" sounds like a vibe. It is not. Recent work defines and measures it directly:
@@ -82,62 +183,11 @@ verified the file is on disk.
 - Agents take shortcuts when they believe resources are running out. Cognition found Claude Sonnet 4.5 **underestimated its remaining context and wrapped up early**, a behavior now called context anxiety ([Inkeep's writeup](https://inkeep.com/blog/context-anxiety)).
 - The failure is mainstream enough that business press covers it: advanced models showing signs of laziness is a named risk for companies betting on agents ([Fortune, July 2026](https://fortune.com/2026/07/28/advanced-ai-models-laziness-open-ai-anthropic/)).
 
-One concrete, painful example of the genre: an agent given 80 files to fix reported all 80 done, with a confident report to back it up. It had opened 11.
+And the v2-specific finding from this project's own controlled test: on a frontier model the visible failures (stubs, placeholders) are gone, while the invisible ones remain, premature done reports and confidently wrong numbers in final summaries. Those two are exactly what gates and the report audit target.
 
 The upside is equally well measured. Effort is steerable. Appending a single "Wait" token and suppressing the end of thinking, called budget forcing, lifts competition math scores by double digits ([s1: Simple test-time scaling, arXiv 2501.19393](https://arxiv.org/abs/2501.19393)). Aider cut lazy coding threefold just by changing the edit format ([unified diffs](https://aider.chat/docs/unified-diffs.html)). And the ceiling keeps rising fast: METR measures the length of task agents can complete at 50 percent reliability doubling roughly every four months ([Time Horizon 1.1, January 2026](https://metr.org/blog/2026-1-29-time-horizon-1-1/)).
 
-So: models default to minimum effort, effort responds to structure, and the structure is what this skill supplies.
-
-## The Depth Tree method
-
-Created by [Leonxlnx](https://github.com/Leonxlnx). This is the core of the skill.
-
-### The rules
-
-1. **Estimate T once, at the root.** T is how long the whole task would take done normally, in one competent pass.
-2. **Split binary, N layers deep.** Layer 1 is the task. Every node splits in two. Leaves are where all real work happens.
-3. **Every leaf gets the full T.** Not a share of it. A leaf that looks trivial still gets the whole budget.
-4. **Per leaf, iterate until a pass finds nothing to improve:** implement completely, then critique as an expert, then hunt defects, then polish.
-5. **Never stop at "works".** Stop when the budget is spent or improvement genuinely runs dry.
-
-```
-tree 3                     X                layer 1: estimate T here
-                         /   \
-                      X.1     X.2           layer 2: decomposition only
-                     /   \   /   \
-                   L1    L2 L3    L4        layer 3: 4 leaves, EACH gets full T
-```
-
-Total effort is T times 2 to the power of N minus 1. `tree 3` is 4T. `tree 7` is 64T. Depth is not a way of slicing the work thinner. It is a dial that multiplies how much work happens.
-
-### Why it beats "try harder" prompting
-
-Telling a model to be thorough is a vibe request, and models regress to minimum effort under it. The tree converts thoroughness into arithmetic:
-
-- **The budget is explicit and per-leaf.** A leaf cannot end early by feeling finished, because its stop condition is a spent budget or a no-improvement pass, not a sense of completion.
-- **Decomposition removes the summary escape hatch.** A model asked for one big thing can hand back a sketch of the whole. A model working leaf 23 of 64 has nothing to summarize. The only move available is the work itself.
-- **Re-estimating is forbidden.** The collapse case, where each leaf gets a fresh smaller estimate, quietly restores ordinary effort. Fixing T at the root is what makes depth multiply.
-- **It matches how effort actually scales in the research.** Budget forcing works by refusing the stop token. The tree is the same refusal, applied at task scale.
-
-### Battle test
-
-The method was used to build [sakura-realm](https://github.com/Leonxlnx/sakura-realm), a real-time procedural 3D landscape, as a `tree 7` run: 64 leaves across 20 file-disjoint modules, contracts written before fan-out, every module followed by an adversarial verification pass that edited code rather than filing reports. The repo, including a volumetric sky, a weather system and a fully procedural tree, shipped with zero art assets.
-
-## What is in the skill
-
-[SKILL.md](SKILL.md) carries the Depth Tree plus enforcement rules distilled from the research above:
-
-| Rule | Counters |
-|---|---|
-| No report until done | Premature completion claims |
-| Acceptance gates before starting | "Looks plausible" passing as done |
-| Verify, do not trust yourself | Confident false reports |
-| Continuation forcing ("Wait") | Early stopping |
-| Finish one line of attack | Underthinking, strategy hopping |
-| Do not simulate work you can do | Overthinking, deliberation instead of action |
-| Ignore resource anxiety | Context-anxiety shortcuts |
-| Full files, full lists, full sweeps | Silent sampling |
-| Banned outputs list | Placeholders, stubs, elisions |
+So: models default to minimum effort, effort responds to structure, and structure that lives in files and hooks beats structure that lives in prose. That is v2.
 
 ## The research
 
@@ -158,7 +208,7 @@ Everything cited, newest first:
 
 ## Contributing
 
-Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the two rules that matter: cite current research for behavioral claims, and keep the Depth Tree semantics intact.
+Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md): cite current research for behavioral claims, keep enforcement structural, and keep it small.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,68 +1,104 @@
 ---
 name: unlazy
-description: Anti-laziness execution discipline for substantial tasks. Use when work keeps coming back half done, when output must be exhaustive rather than fast, or on any invocation like /unlazy, "tree N", or "do not stop until it is done". Core method is the Depth Tree, which multiplies effort with depth instead of dividing it.
+description: Anti-laziness execution discipline for substantial tasks. Use when work keeps coming back half done, when an agent reports done before it is done, when output must be exhaustive rather than fast, on long autonomous runs that tend to stall at 80 percent, or on any invocation like /unlazy, "tree N", "gates", or "do not stop until it is done". v2 enforces completion through gate files and runnable checks instead of promises. Core method is the Depth Tree, which decomposes work into leaves that each get finished against their own gates.
 license: MIT
 metadata:
   author: Leonxlnx
   source: https://github.com/Leonxlnx/unlazy
+  version: 2.0.0
 ---
 
 # Unlazy
 
-You are running under anti-laziness discipline. The failure mode this skill exists to kill is output that is technically responsive but minimum effort: stubbed code, placeholder comments, single-pass answers, premature "done" reports, and quietly narrowed scope. Research across 2025 and 2026 shows these are systematic model behaviors, not accidents: premature truncation and partial compliance with multi-part requests, early abandonment of promising reasoning paths, and shortcut-taking when the model believes resources are running out. Treat your own first instinct to wrap up as a symptom, not a signal.
+You are running under anti-laziness discipline. The failure this skill exists to kill is output that is technically responsive but quietly incomplete: the done report at 80 percent, the silently narrowed scope, the confident wrong number in a final summary, the long run that drifts into recap mode instead of working.
 
-## The Depth Tree method (core)
+v1 of this skill fought these with instructions. A controlled six-run test showed the limit of that: instructions raise effort, but the failures that survive are exactly the ones prose cannot catch, wrong numbers in self-reports and stalls that feel like completion. So v2 moves enforcement out of your goodwill and into files and checks. You do not promise you are done. You prove it against a ledger.
 
-Created by Leonxlnx. This is the main tool of this skill.
+## Rule zero: gates before work
 
-When the user says "tree N" for a task X, or when you choose depth yourself:
+Before starting real work, write the acceptance gates to a file. Not in your head, not in prose, in a file: `GATES.md` in the working directory, using the format in [templates/gates-leaf.md](templates/gates-leaf.md). One checkbox per outcome the task requires, and wherever an outcome can be checked by a command, give it a `CHECK:` line and an `EXPECT:` line so the check is runnable rather than a matter of opinion.
 
-1. **Estimate T at layer 1.** T is the time a competent, normal, single pass over the WHOLE task would take. Write it down before splitting. T is fixed once; never re-derive it per node.
+Why a file: your intentions do not survive a long context, files do. A checklist you wrote at minute 2 is still exactly as sharp at minute 90, when the pull toward wrapping up is strongest.
 
-2. **Split binary, N layers deep.** Layer 1 is the task itself. Every node splits into exactly 2 children. So tree 3 has 4 leaves, tree 5 has 16, tree 7 has 64. Leaves are the only places where real work happens; every layer above them is decomposition only.
+Done means every box is checked with evidence recorded. Run the bundled checker to execute the checks and record evidence for you:
 
-3. **The rule that matters: every leaf gets the FULL budget T.** Not T divided by the number of leaves. A trivial looking leaf still gets the whole T. Depth therefore multiplies total effort by 2 to the power of N minus 1. That multiplication is the entire point of the method. If re-estimating per leaf feels tempting, notice that it collapses the tree back into ordinary work.
+```
+node <this-skill-dir>/scripts/gate-check.mjs GATES.md
+```
 
-4. **Contracts before fan-out.** If leaves will run in parallel or touch shared surfaces, write the interfaces, data ownership and conventions down FIRST. Deep effort that does not integrate is waste.
+Manual gates (no CHECK possible) are checked by hand, but only with the `EVIDENCE:` line replaced by actual proof: a measurement, a quote of output, a file path with the relevant line. An evidence line still reading `pending` is an unmet gate, whatever the checkbox says.
 
-5. **Work each leaf in passes until a pass produces no improvement:**
-   - Pass 1: implement completely. No placeholders, no "rest left as exercise", no TODO.
-   - Pass 2: re-read what you produced as a domain expert would. Name the cheap version of each part and replace it with the good version.
-   - Pass 3: hunt defects. Edge cases, correctness proofs, performance, the tells that something is fake or generated. Fix everything found.
-   - Pass 4: polish that costs nothing extra. Tuned constants beat new features.
+If a gate becomes genuinely impossible, do not quietly drop it. Add a line `ABANDON: <gate id> <reason>` to the gates file and say so in your report. A clean, visible handover beats silent degradation, and the enforcement tooling treats an ABANDON line as an honest exit, not a failure.
 
-6. **Stop condition.** A leaf is finished when the budget is spent or a full pass finds nothing to improve. "It works" is never the stop condition.
+## Pick a mode
 
-## Enforcement rules
+**Solo** (default). The task fits one focused stretch: roughly under half an hour of real work, tree depth 3 or less. One `GATES.md`, work until it is fully checked, report with the ledger pasted.
 
-These are behavioral rules grounded in current research. Follow them for the whole session, not just inside the tree.
+**Orchestrated**. The task is a build: tree depth 4 or more, or clearly beyond one sitting. Decompose per [references/method.md](references/method.md), write `PLAN.md` plus one gates file per leaf under `gates/`, and run each leaf as a fresh subagent with a narrow brief. Read [references/orchestration.md](references/orchestration.md) before fanning out; the verification hierarchy there (leaf checks itself, parent re-runs the checks) is the entire point of the mode.
 
-**No report until done.** Reporting progress is not progress. If you notice yourself composing a status summary while acceptance gates are unmet, that is the laziness reflex firing. Return to work. Deliver one report, at the end, with measurements.
+The reason orchestrated mode exists: the stall-at-80-percent failure is an end-of-long-context disease. A fresh context per leaf means every leaf starts with full attention. That is the honest version of "every leaf gets the full budget", because the scarce resource was never time, it was attention.
 
-**Define acceptance gates before starting.** Concrete, checkable pass or fail conditions: a test passes, a number clears a threshold, a render shows the change. The task is done when gates pass, not when the output looks plausible.
+## The Depth Tree, v2
 
-**Verify, do not trust yourself.** Claims require measurement. Run it, render it, profile it, count it. If you cannot verify a claim, say so explicitly instead of asserting it.
+Created by Leonxlnx. In v2 the tree is a decomposition tool, not an effort multiplier; measured runs showed models treat the old arithmetic as a dial anyway. What depth buys you is structure:
 
-**Continuation forcing.** When you feel finished, do not conclude. Append the word "Wait" to your own reasoning and re-examine the result once more. This mirrors budget forcing from test-time scaling research, where suppressing the end of thinking and appending "Wait" measurably improves outcomes.
+1. **Split at natural joints, N layers deep.** Layer 1 is the task. Leaves are where work happens.
+2. **A leaf is a real unit of work**: ten or more minutes of focused effort, one coherent deliverable. If your leaves come out smaller, you went one layer too deep; back off.
+3. **Contracts before fan-out.** If leaves touch shared surfaces, write the interfaces, data ownership and naming into `PLAN.md` first. Deep effort that does not integrate is waste.
+4. **Branches get gates too.** Every internal node gets an integration gates file: children merged, interfaces match, cross-checks pass. Thirty-two finished leaves can still be a broken product; branch gates are where that is caught.
+5. **Effort per leaf comes from its gates**, not from N. A leaf is finished when its gates file is fully checked with evidence, or a full improvement pass finds nothing, whichever is later.
 
-**Finish one line of attack.** Underthinking research shows models abandon promising approaches prematurely and hop between strategies. Before switching approach, state what the current approach still has left to give and why switching wins. If you cannot, keep going.
+Scale guidance: tree 2 or 3 for a feature, a bug hunt, a document, solo mode. Tree 4 or 5 for a subsystem or serious refactor. Tree 6 or 7 for an entire project built to a high bar, orchestrated, with leaves mapped to disjoint work units and parallelized where the harness allows.
 
-**Do not simulate work you can do.** Overthinking research on agents shows the inverse failure: models deliberate instead of acting. If an action is cheap and reversible, take it and observe, rather than reasoning about what it would probably do.
+## Work each leaf in passes
 
-**Ignore resource anxiety.** Models take shortcuts when they believe context or time is short, and they underestimate what remains. Never compress, summarize or stub work because the end feels near. If a real limit approaches, say so and hand over cleanly instead of silently degrading.
+1. **Implement completely.** No placeholders, no TODO, no "rest as exercise".
+2. **Re-read as a domain expert.** Name the cheap version of each part, replace it with the good version.
+3. **Hunt defects.** Edge cases, correctness, performance, the tells that something is fake. Fix what you find.
+4. **Polish that costs nothing.** Tuned constants beat new features.
 
-**Full files, full lists, full sweeps.** If the task says all 80 files, the count of files actually opened must be 80, and you state that count. Sampling is only acceptable when declared.
+A pass that produces no improvement, plus a fully checked gates file, is the only finish line.
 
-**Banned outputs.** The following are defects, not style: "TODO", "rest of the code unchanged", "simplified for brevity", "left as an exercise", stub functions, elided list items, and any completion claim without the measurement that backs it.
+## Report audit
 
-## Scale guidance
+The single most reproducible failure in tested runs: final reports whose numbers were wrong while their substance was right. Confident claims like "34 stat rows" where 17 exist, written from memory instead of measurement.
 
-- tree 2 or 3: a feature, a bug hunt, a document. 2 to 4 leaves.
-- tree 4 or 5: a subsystem, a refactor, a serious review. 8 to 16 leaves.
-- tree 6 or 7: an entire project built to a high bar. 32 to 64 leaves. Map leaves onto disjoint work units and parallelize where the harness allows.
+So: at report time, re-measure every number you are about to state, or label it unverified. Paste the gates ledger with its count, N of N checked. A report is a set of claims backed by a ledger, never a vibe of completion.
 
-When the user gives no depth, pick the smallest N whose leaf count covers the task's natural parts, then go one deeper.
+## Behavioral rules
+
+The keepers from v1, still true, now backed by structure:
+
+- **No report until the ledger is full.** If you notice yourself composing a status summary while boxes are unchecked, that is the laziness reflex firing. Open the gates file and pick the next unchecked box.
+- **When you feel finished, check instead of concluding.** Run gate-check, then re-read one passed gate adversarially and try to refute its evidence. This is continuation forcing made mechanical.
+- **Finish one line of attack.** Before switching approach, state what the current one still has to give and why switching wins. If you cannot, keep going.
+- **Do not simulate work you can do.** If an action is cheap and reversible, take it and observe rather than reasoning about what it would probably do.
+- **Ignore resource anxiety.** Never compress, summarize or stub because the end feels near. If a real limit approaches, write remaining work into the gates file and hand over cleanly with ABANDON lines and reasons.
+- **Full files, full lists, full sweeps.** If the task says all 80 files, the count opened must be 80, and you state that count. Sampling is only acceptable when declared.
+
+## Token economy
+
+Discipline is not maximalism, and enforcement should be nearly free. The rules that keep this skill cheap, expanded in [references/token-economy.md](references/token-economy.md):
+
+- Checks run as shell commands, not as you re-reading everything you wrote.
+- Evidence is capped: the deciding lines of output, never full logs.
+- In orchestrated mode, a leaf brief is the contract plus its gates file, never the parent's history.
+- Append to `PLAN.md`'s status log, do not rewrite the file.
+- Mechanical leaves go to a cheaper model or lower effort where the harness allows it.
+- Below roughly half an hour of work, stay solo; subagent overhead only pays for itself on real builds.
+
+## Hard enforcement (Claude Code, optional)
+
+If the harness is Claude Code, this skill ships a Stop hook that structurally blocks ending the turn while `GATES.md` or `gates/*.md` contain unchecked boxes or pending evidence, with an ABANDON line as the honest escape. It converts "no report until done" from a rule into a wall.
+
+It changes harness behavior, so never install it silently. When a task would clearly benefit, offer it once:
+
+```
+node <this-skill-dir>/scripts/install-hooks.mjs
+```
+
+and tell the user what it does and how to remove it (`--uninstall`). Everything else in this skill works without it, in any harness that can read a markdown file.
 
 ## What this skill is not
 
-It is not maximalism for its own sake. Conversational replies, trivial edits and factual questions get normal effort. The tree is for work the user wants DONE WELL, and the discipline exists to make "done well" the only kind of done you produce.
+Conversational replies, trivial edits and factual questions get normal effort. No gates file for a one-line fix. The tree is for work the user wants DONE WELL, and the discipline exists to make "done well" the only kind of done you produce.

--- a/references/gates.md
+++ b/references/gates.md
@@ -1,0 +1,66 @@
+# Gate file format
+
+The machine-readable contract between "I say it is done" and "it is done".
+Both bundled scripts (`gate-check.mjs`, `stop-hook.mjs`) parse exactly this
+format, so any deviation weakens enforcement.
+
+## Format
+
+```markdown
+# Gates: <scope name>
+
+Scope: <one line>
+
+- [ ] G1: <outcome>
+  CHECK: <shell command>
+  EXPECT: <substring or /regex/>
+  EVIDENCE: pending
+
+- [ ] G2: <manual outcome>
+  EVIDENCE: pending
+
+ABANDON: G2 <reason, only if a gate had to be surrendered>
+```
+
+## Parsing rules
+
+- A gate starts at a line matching `- [ ]` or `- [x]` (case-insensitive x).
+- Indented `CHECK:`, `EXPECT:`, `EVIDENCE:` lines up to the next gate belong
+  to the gate above them.
+- `EXPECT:` is a plain substring match against the command's combined
+  stdout+stderr, unless wrapped in slashes, then it is a JavaScript regex
+  (e.g. `/8\/8 passed/`).
+- `ABANDON: G<n> <reason>` anywhere in the file marks that gate as
+  honestly surrendered. Tools treat it as resolved but reports must list it.
+
+## What counts as UNMET
+
+A gate is unmet if any of these hold:
+
+1. Its box is unchecked, and no ABANDON line names it.
+2. Its box is checked but `EVIDENCE:` still reads `pending`. A checkbox is a
+   claim; evidence is the proof. Checked-without-evidence is the exact
+   failure mode this system exists to catch, so it counts as worse than
+   unchecked, not better.
+
+## Writing good gates
+
+- **State outcomes, not activities.** "All 8 planets clickable" is checkable.
+  "Work on planet interaction" is not.
+- **Prefer runnable gates.** Every CHECK you write converts model-tokens of
+  self-assessment into a free shell command. If you cannot think of a CHECK,
+  ask whether the outcome is observable at all; if it is not, sharpen it.
+- **Make EXPECT decisive.** Match the line that can only appear on success
+  (`8/8 passed`), not one that appears either way (`done`).
+- **Cap evidence.** gate-check records the deciding tail of output. When
+  filling manual evidence by hand, quote the deciding lines or cite
+  `file:line`, never paste a log.
+- **Five to twelve gates per leaf** is the useful range. Two gates means the
+  leaf is under-specified; twenty means the leaf should have been two leaves.
+
+## Numbers rule
+
+Any number that will appear in a final report deserves its own gate with a
+CHECK that measures it. Measured runs of v1 showed reports whose only false
+claims were numbers stated from memory. If a number matters enough to
+report, it matters enough to measure at report time.

--- a/references/method.md
+++ b/references/method.md
@@ -1,0 +1,64 @@
+# The Depth Tree, v2
+
+Created by Leonxlnx. v1 stated the tree as arithmetic: split N layers, give
+every leaf the full root budget, effort multiplies as 2^(N-1). A controlled
+six-run test (see the README) measured what models actually do with that
+instruction: they treat depth as a thoroughness dial and ignore the
+arithmetic. tree 6 cost roughly 1.0 to 1.5 times tree 3, never 8 times.
+The dial worked; the math was fiction.
+
+v2 keeps what the tree is genuinely good at, decomposition and structure,
+and moves the effort guarantee to where it can actually be enforced: per-leaf
+gates and fresh per-leaf contexts.
+
+## The rules
+
+1. **Layer 1 is the task.** Split at natural joints, binary where natural
+   joints allow, N layers deep. Leaves are the only places real work happens;
+   every layer above them is decomposition and integration.
+
+2. **A leaf is a real unit of work.** Ten or more minutes of focused effort,
+   one coherent deliverable, one gates file. If splitting produces leaves
+   smaller than that, you went one layer too deep; back off a layer. Depth
+   follows the task's joints. It is not a number you crank for effort.
+
+3. **Contracts before fan-out.** Interfaces, data ownership, naming, error
+   conventions go into PLAN.md before any leaf starts. In orchestrated mode
+   no two leaves may own the same file; if they seem to need to, the split
+   is wrong or the shared thing belongs in the contract.
+
+4. **Leaves get gates; branches get gates.** A leaf's gates prove its
+   deliverable. A branch's gates prove integration: children merged,
+   interfaces match, end-to-end behavior works, no sibling regressions.
+   The most expensive failure of deep trees is thirty-two locally perfect
+   leaves that do not compose; branch gates exist to catch exactly that.
+
+5. **Effort per leaf comes from the leaf's gates plus the four passes**
+   (implement fully, expert re-read, defect hunt, free polish). A leaf is
+   finished when its gates are fully met with evidence AND a full pass finds
+   nothing to improve. "Budget spent" is no longer a finish line, because
+   budgets were the part models routinely re-negotiated with themselves.
+
+## Where the effort guarantee actually lives now
+
+| v1 said | v2 does |
+|---|---|
+| every leaf gets full budget T | every leaf gets a fresh context and its own gates |
+| effort = 2^(N-1) x T | effort = whatever it takes to check every box with evidence |
+| no report until done (prose) | stop-hook and ledger make early reports structurally visible |
+| verify, do not trust yourself | CHECK commands run in the shell; parent re-runs them |
+
+## Choosing N
+
+- **tree 2 or 3**: a feature, a bug hunt, a document. Solo mode, one gates
+  file, 2 to 4 leaves worked in sequence in one session.
+- **tree 4 or 5**: a subsystem, a refactor, a serious review. Consider
+  orchestrated mode; 8 to 16 leaves is past what one context holds well.
+- **tree 6 or 7**: an entire project built to a high bar. Orchestrated mode,
+  leaves mapped onto disjoint work units, parallelized where the harness
+  allows, branch gates at every merge point.
+
+When the user gives no depth, pick the smallest N whose leaves match the
+task's natural parts. Do not go one deeper by default; go one deeper only
+when a leaf fails the "real unit of work" test in the other direction, that
+is, when a leaf would clearly hide multiple deliverables inside it.

--- a/references/orchestration.md
+++ b/references/orchestration.md
@@ -1,0 +1,71 @@
+# Orchestrated mode: leaves as fresh agents
+
+For tree depth 4+ or any build clearly beyond one sitting. The core insight:
+the stall-at-80-percent failure is an end-of-long-context disease. Attention,
+not time, is the scarce resource, and a fresh subagent per leaf resets it.
+
+## The driver loop
+
+You (the main session) are the driver. You do not implement leaves; you
+plan, dispatch, verify, and integrate.
+
+1. **Plan.** Write PLAN.md (contract, tree, gates file per leaf and branch)
+   from templates/PLAN.md. This is the only step where the whole task must
+   fit in one head.
+2. **Dispatch one leaf.** Spawn a subagent whose entire brief is:
+   - the contract section of PLAN.md (not the whole file, not your history)
+   - its own gates file, verbatim
+   - the instruction: work the four passes until every gate is met with
+     evidence, then stop; if a gate is impossible, ABANDON it with a reason.
+3. **Verify, never trust.** When the leaf returns, re-run its checks
+   yourself: `node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-x.md`
+   and rerun a spot-check of the CHECK commands. A leaf that checked its own
+   boxes without evidence gets sent back with the specific unmet gates named.
+   This is the layer that makes self-certification worthless.
+4. **Log and advance.** Append one line to PLAN.md's status log. Dispatch the
+   next leaf. When all children of a branch are verified, work the branch's
+   integration gates yourself (or dispatch an integration leaf for it).
+5. **Report.** Only when the root's gates are met. Paste the ledger, N of N,
+   with every ABANDON line surfaced, and re-measure every number you state.
+
+## Parallelism
+
+Leaves whose file ownership is disjoint (the contract guarantees this) can
+run concurrently if the harness supports parallel subagents. Parallelism
+buys wall-clock time, not token savings; do not use it as an excuse to skip
+per-leaf verification. If two leaves ever need the same file, fix the plan,
+do not coordinate through hope.
+
+## Verification hierarchy
+
+Three layers, weakest to strongest, each catching what the layer below
+misses:
+
+1. **Leaf self-check**: gate-check run by the leaf itself. Catches honest
+   incompleteness, misses self-deception.
+2. **Parent re-run**: the driver re-executes the checks. Catches
+   self-deception and environment differences.
+3. **Stop-hook** (Claude Code, optional): structurally blocks a session from
+   ending while gates are unmet. Catches the driver itself drifting into
+   report mode.
+
+Prose discipline is layer zero and it is the weakest; that is the lesson v2
+is built on. Prefer moving any repeated judgment call up this hierarchy:
+if you find yourself re-checking the same thing twice by reading, write a
+CHECK command for it.
+
+## Model and effort tiering
+
+Where the harness allows choosing a model or reasoning effort per subagent,
+tier by leaf type. Mechanical leaves (rename sweeps, fixture generation,
+applying a decided pattern across files) go to a cheaper model or lower
+effort. Design leaves, integration branches, and every verification pass
+stay on the strong model. The driver stays on the strong model always; a
+weak driver invalidates every verification above layer one.
+
+## When NOT to orchestrate
+
+Below roughly half an hour of real work, subagent overhead (context
+re-establishment per leaf) costs more than it buys. Stay solo: one GATES.md,
+one session, same discipline. The gates still do their job; you just skip
+the dispatch machinery.

--- a/references/token-economy.md
+++ b/references/token-economy.md
@@ -1,0 +1,57 @@
+# Token economy
+
+Thoroughness and cost discipline are not opposites; the six-run test that
+motivated v2 measured both. The tree runs produced deeper work at 1.6 to
+3.9 times the output tokens, but their input-side cost ballooned to tens of
+millions of cached-context tokens because one ever-growing context carried
+everything. These rules keep v2's enforcement nearly free and its deep runs
+affordable.
+
+## Enforcement should cost almost nothing
+
+- **Checks are shell commands, not re-reading.** Every CHECK line converts
+  "model re-derives whether this is true" (thousands of tokens, fallible)
+  into a subprocess (zero tokens, repeatable). If you notice yourself
+  re-verifying something by reading, that is a missing CHECK line.
+- **The stop-hook is a regex scan, not a model call.** Blocking early stops
+  costs milliseconds and zero tokens. Structural enforcement is the cheapest
+  enforcement there is.
+- **Evidence is capped.** The deciding tail of output, roughly five lines,
+  never a full log. A gates file should stay readable in one screen per
+  leaf, because it gets re-read often.
+
+## Context hygiene for long runs
+
+- **Lean leaf briefs.** A dispatched leaf receives the contract plus its own
+  gates file. It never receives the driver's transcript, the other leaves'
+  outputs, or the full PLAN.md. Measured baseline: a monolithic deep run
+  consumed roughly 58 million cached input tokens; leaf isolation caps each
+  context at what its work needs.
+- **Append, never rewrite.** PLAN.md's status log is append-only. Rewriting
+  a file's head invalidates prompt cache for everything after it; appending
+  keeps the stable prefix stable. The same goes for gates files: gate-check
+  edits lines in place rather than regenerating the file.
+- **Progressive disclosure.** This skill keeps its core small and loads
+  references only when the mode needs them. Extend it the same way: task
+  documents split into a small always-loaded core and on-demand details.
+
+## Spend where it compounds
+
+- **Tier models by leaf type** (see orchestration.md): cheap model for
+  mechanical leaves, strong model for design, integration and every
+  verification pass.
+- **Do not orchestrate small tasks.** Under roughly half an hour of work,
+  each subagent's context re-establishment outweighs the attention gain.
+  Solo mode with a gates file gives you most of the discipline at a fraction
+  of the cost.
+- **Depth is not a spend dial.** Measured: within one context, deeper trees
+  cost about the same and redistribute effort toward verification. What
+  multiplies cost is orchestration, and it should multiply it, because each
+  leaf buys a fresh context. Choose depth by the leaf-size rule in
+  method.md, then let the mode decision (solo vs orchestrated) set the
+  budget honestly.
+- **Verification is the last thing to cut.** In the motivating test, the
+  cheapest run's only hard failure (content invisible in background tabs)
+  was precisely a missing verification pass, and the fix cost its siblings
+  a few hundred tokens of checking. Cut narration, cut recap, cut log
+  pasting; never cut the check that would have caught the bug.

--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// gate-check.mjs : run the CHECK commands in gate files, flip boxes, record evidence.
+// Zero dependencies. Node 16+. Part of the unlazy skill (v2).
+//
+// Usage:
+//   node gate-check.mjs [file ...]          run unmet gates' checks, update files
+//   node gate-check.mjs --status [file ...] report only, change nothing
+//   node gate-check.mjs --timeout 60 ...    per-check timeout in seconds (default 120)
+//
+// Files default to GATES.md plus gates/*.md in the current directory.
+// Exit codes: 0 = all gates met (or honestly abandoned), 1 = unmet gates remain,
+//             2 = usage or parse error.
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+const statusOnly = args.includes("--status");
+let timeoutSec = 120;
+const tIdx = args.indexOf("--timeout");
+if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+
+function defaultFiles(dir) {
+  const found = [];
+  const top = join(dir, "GATES.md");
+  if (existsSync(top)) found.push(top);
+  const gdir = join(dir, "gates");
+  if (existsSync(gdir)) {
+    for (const f of readdirSync(gdir)) {
+      if (f.endsWith(".md")) found.push(join(gdir, f));
+    }
+  }
+  return found;
+}
+
+const files = fileArgs.length ? fileArgs : defaultFiles(process.cwd());
+if (!files.length) {
+  console.error("gate-check: no gate files found (GATES.md or gates/*.md)");
+  process.exit(2);
+}
+
+const GATE_RE = /^- \[( |x|X)\] (.*)$/;
+const ATTR_RE = /^\s+(CHECK|EXPECT|EVIDENCE):\s?(.*)$/;
+const ABANDON_RE = /^ABANDON:\s*(\S+)\s*(.*)$/;
+
+function parse(lines) {
+  const gates = [];
+  const abandoned = new Map(); // id -> reason
+  let cur = null;
+  lines.forEach((line, i) => {
+    const g = line.match(GATE_RE);
+    if (g) {
+      const id = (g[2].match(/^(\S+?):/) || [null, `line${i + 1}`])[1];
+      cur = {
+        line: i, checked: g[1].toLowerCase() === "x",
+        title: g[2].trim().replace(/^\S+?:\s*/, ""),
+        id,
+        check: null, expect: null, evidence: null, evidenceLine: -1,
+      };
+      gates.push(cur);
+      return;
+    }
+    const a = cur && line.match(ATTR_RE);
+    if (a) {
+      const key = a[1].toLowerCase();
+      cur[key] = a[2].trim();
+      if (key === "evidence") cur.evidenceLine = i;
+      return;
+    }
+    const ab = line.match(ABANDON_RE);
+    if (ab) abandoned.set(ab[1].replace(/:$/, ""), ab[2] || "(no reason)");
+    if (/^#|^- /.test(line) && !g) cur = null;
+  });
+  return { gates, abandoned };
+}
+
+function expectMatches(expect, output) {
+  const rx = expect.match(/^\/(.+)\/([a-z]*)$/);
+  if (rx) {
+    try { return new RegExp(rx[1], rx[2]).test(output); } catch { return false; }
+  }
+  return output.includes(expect);
+}
+
+function tail(output, max = 200) {
+  const lines = output.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+  const last = lines.slice(-2).join(" | ");
+  return (last || "(no output)").slice(0, max);
+}
+
+let totalUnmet = 0;
+let totalMet = 0;
+let totalAbandoned = 0;
+
+for (const file of files) {
+  let text;
+  try { text = readFileSync(file, "utf8"); } catch (e) {
+    console.error(`gate-check: cannot read ${file}: ${e.message}`);
+    process.exit(2);
+  }
+  const lines = text.split(/\r?\n/);
+  const { gates, abandoned } = parse(lines);
+  if (!gates.length) {
+    console.log(`${file}: no gates found`);
+    continue;
+  }
+  let changed = false;
+
+  for (const gate of gates) {
+    const isAbandoned = abandoned.has(gate.id);
+    const pendingEvidence = !gate.evidence || /^pending$/i.test(gate.evidence);
+
+    if (isAbandoned) { totalAbandoned++; continue; }
+
+    // Run checks for gates that are unchecked, or checked but missing evidence.
+    const needsRun = !statusOnly && gate.check && (!gate.checked || pendingEvidence);
+    if (needsRun) {
+      const res = spawnSync(gate.check, {
+        shell: true, encoding: "utf8", timeout: timeoutSec * 1000,
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      const output = `${res.stdout || ""}\n${res.stderr || ""}`;
+      // With an EXPECT, the match decides (a check may exit non-zero by design);
+      // without one, the exit code decides.
+      const ok = gate.expect ? expectMatches(gate.expect, output) : res.status === 0;
+      if (ok) {
+        lines[gate.line] = lines[gate.line].replace(/^- \[ \]/, "- [x]");
+        if (gate.evidenceLine !== -1) {
+          const indent = lines[gate.evidenceLine].match(/^\s*/)[0];
+          lines[gate.evidenceLine] = `${indent}EVIDENCE: ${tail(output)}`;
+        }
+        gate.checked = true;
+        gate.evidence = tail(output);
+        changed = true;
+        console.log(`  PASS ${gate.id}: ${gate.title}`);
+      } else {
+        const why = res.error ? res.error.message : tail(output);
+        console.log(`  FAIL ${gate.id}: ${gate.title}\n       ${why}`);
+      }
+    }
+
+    const evidenceNow = gate.evidence && !/^pending$/i.test(gate.evidence);
+    if (gate.checked && evidenceNow) totalMet++;
+    else {
+      totalUnmet++;
+      if (statusOnly) {
+        const why = !gate.checked ? "unchecked" : "checked but EVIDENCE pending";
+        console.log(`  UNMET ${gate.id} (${why}): ${gate.title}`);
+      }
+    }
+  }
+
+  if (changed) writeFileSync(file, lines.join("\n"));
+  console.log(`${file}: ${gates.length} gates`);
+}
+
+if (totalUnmet === 0) {
+  console.log(`ALL MET (${totalMet} met${totalAbandoned ? `, ${totalAbandoned} abandoned` : ""})`);
+  process.exit(0);
+} else {
+  console.log(`UNMET: ${totalUnmet} (met: ${totalMet}${totalAbandoned ? `, abandoned: ${totalAbandoned}` : ""})`);
+  process.exit(1);
+}

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// install-hooks.mjs : register (or remove) the unlazy Stop hook in Claude Code settings.
+//
+// Default target: <cwd>/.claude/settings.local.json  (personal, per-project,
+// conventionally untracked, so the machine-specific absolute path never lands in git).
+//
+//   node install-hooks.mjs               install into project settings.local.json
+//   node install-hooks.mjs --shared      install into project settings.json (tracked)
+//   node install-hooks.mjs --global      install into ~/.claude/settings.json
+//   node install-hooks.mjs --uninstall   remove from the chosen target (same flags)
+//
+// Idempotent: running install twice changes nothing.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+const args = process.argv.slice(2);
+const uninstall = args.includes("--uninstall");
+const global_ = args.includes("--global");
+const shared = args.includes("--shared");
+
+const hookScript = join(dirname(fileURLToPath(import.meta.url)), "stop-hook.mjs");
+const MARKER = "unlazy"; // identifies our entries: command mentions unlazy + stop-hook.mjs
+
+const target = global_
+  ? join(homedir(), ".claude", "settings.json")
+  : join(process.cwd(), ".claude", shared ? "settings.json" : "settings.local.json");
+
+let settings = {};
+if (existsSync(target)) {
+  try { settings = JSON.parse(readFileSync(target, "utf8")); }
+  catch (e) {
+    console.error(`Refusing to touch ${target}: it exists but is not valid JSON (${e.message}).`);
+    process.exit(1);
+  }
+}
+
+settings.hooks = settings.hooks || {};
+const stopHooks = Array.isArray(settings.hooks.Stop) ? settings.hooks.Stop : [];
+
+const isOurs = (entry) =>
+  Array.isArray(entry?.hooks) &&
+  entry.hooks.some(h => typeof h?.command === "string" &&
+    h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER));
+
+const kept = stopHooks.filter(e => !isOurs(e));
+
+if (uninstall) {
+  if (kept.length === stopHooks.length) {
+    console.log(`Nothing to remove: no unlazy Stop hook found in ${target}`);
+    process.exit(0);
+  }
+  settings.hooks.Stop = kept;
+  if (!settings.hooks.Stop.length) delete settings.hooks.Stop;
+  if (!Object.keys(settings.hooks).length) delete settings.hooks;
+  writeFileSync(target, JSON.stringify(settings, null, 2) + "\n");
+  console.log(`Removed unlazy Stop hook from ${target}`);
+  process.exit(0);
+}
+
+const entry = {
+  hooks: [{
+    type: "command",
+    command: `node "${hookScript}"`,
+    timeout: 20,
+  }],
+};
+
+if (stopHooks.some(isOurs)) {
+  console.log(`Already installed in ${target} (idempotent, nothing changed).`);
+  process.exit(0);
+}
+
+settings.hooks.Stop = [...kept, entry];
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, JSON.stringify(settings, null, 2) + "\n");
+
+console.log(`Installed unlazy Stop hook into ${target}
+  command: node "${hookScript}"
+  effect:  while GATES.md or gates/*.md in the working directory contain unmet
+           gates, ending the turn is blocked (max 6 blocks without progress,
+           ABANDON lines are honored as an honest exit).
+  remove:  node "${fileURLToPath(import.meta.url)}"${global_ ? " --global" : shared ? " --shared" : ""} --uninstall
+  note:    add .unlazy-hook-state.json to your .gitignore`);

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// stop-hook.mjs : Claude Code Stop hook for the unlazy skill (v2).
+//
+// Structurally blocks ending the turn while GATES.md / gates/*.md contain
+// unmet gates. Zero tokens: this is a file scan, not a model call.
+//
+// Behavior:
+//   - No gate files in cwd            -> allow (skill not active here)
+//   - All gates met or abandoned      -> allow
+//   - Unmet gates, progress happening -> block with a one-line reason
+//   - Unmet gates, NO progress after MAX_BLOCKS consecutive blocks -> allow
+//     with a warning (never traps a genuinely stuck agent; Claude Code
+//     additionally force-releases after 8 consecutive blocks)
+//
+// Progress = the combined content of the gate files changed since last block.
+// State lives in .unlazy-hook-state.json next to the gates (add to .gitignore).
+//
+// Contract (docs: code.claude.com/docs/en/hooks):
+//   stdin  JSON with { cwd, stop_hook_active, ... }
+//   stdout {"decision":"block","reason":"..."} + exit 0 to block; exit 0 silent to allow.
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+const MAX_BLOCKS = 6;
+
+function readStdin() {
+  try { return readFileSync(0, "utf8"); } catch { return "{}"; }
+}
+
+let payload = {};
+try { payload = JSON.parse(readStdin() || "{}"); } catch { /* stay permissive */ }
+const cwd = payload.cwd || process.cwd();
+
+function gateFiles(dir) {
+  const found = [];
+  const top = join(dir, "GATES.md");
+  if (existsSync(top)) found.push(top);
+  const gdir = join(dir, "gates");
+  if (existsSync(gdir)) {
+    try {
+      for (const f of readdirSync(gdir)) if (f.endsWith(".md")) found.push(join(gdir, f));
+    } catch { /* ignore */ }
+  }
+  return found;
+}
+
+const files = gateFiles(cwd);
+if (!files.length) process.exit(0); // no gates, nothing to enforce
+
+const GATE_RE = /^- \[( |x|X)\] (.*)$/;
+const EVIDENCE_RE = /^\s+EVIDENCE:\s?(.*)$/;
+const ABANDON_RE = /^ABANDON:\s*(\S+)/;
+
+let combined = "";
+const unmet = [];
+
+for (const file of files) {
+  let text = "";
+  try { text = readFileSync(file, "utf8"); } catch { continue; }
+  combined += text;
+  const lines = text.split(/\r?\n/);
+  const abandoned = new Set(
+    lines.map(l => (l.match(ABANDON_RE) || [])[1]).filter(Boolean).map(s => s.replace(/:$/, ""))
+  );
+  let cur = null; // { id, checked, evidence }
+  const flush = () => {
+    if (!cur || abandoned.has(cur.id)) { cur = null; return; }
+    const pending = cur.evidence === null || /^pending$/i.test(cur.evidence);
+    if (!cur.checked || pending) unmet.push(cur.id);
+    cur = null;
+  };
+  for (const line of lines) {
+    const g = line.match(GATE_RE);
+    if (g) {
+      flush();
+      cur = {
+        checked: g[1].toLowerCase() === "x",
+        id: (g[2].match(/^(\S+?):/) || [null, g[2].trim().slice(0, 24)])[1],
+        evidence: null,
+      };
+      continue;
+    }
+    const ev = cur && line.match(EVIDENCE_RE);
+    if (ev) cur.evidence = ev[1].trim();
+  }
+  flush();
+}
+
+if (!unmet.length) process.exit(0); // everything met or honestly abandoned
+
+// Progress-aware loop guard.
+const statePath = join(cwd, ".unlazy-hook-state.json");
+const hash = createHash("sha256").update(combined).digest("hex").slice(0, 16);
+let state = { hash: "", blocks: 0 };
+try { state = JSON.parse(readFileSync(statePath, "utf8")); } catch { /* fresh */ }
+if (state.hash !== hash) state = { hash, blocks: 0 }; // progress -> reset counter
+state.blocks += 1;
+try { writeFileSync(statePath, JSON.stringify(state)); } catch { /* non-fatal */ }
+
+if (state.blocks > MAX_BLOCKS) {
+  // No progress across MAX_BLOCKS consecutive stops: release rather than trap.
+  console.log(JSON.stringify({
+    systemMessage: `unlazy: releasing after ${MAX_BLOCKS} blocks without gate progress; ${unmet.length} gates remain unmet (${unmet.slice(0, 4).join(", ")}).`,
+  }));
+  process.exit(0);
+}
+
+const list = unmet.slice(0, 5).join(", ") + (unmet.length > 5 ? `, +${unmet.length - 5} more` : "");
+console.log(JSON.stringify({
+  decision: "block",
+  reason: `unlazy: ${unmet.length} gate(s) unmet: ${list}. Work the next unchecked gate (run gate-check.mjs to execute CHECK lines), or add "ABANDON: <id> <reason>" if one is genuinely impossible. Done means every box checked with evidence.`,
+}));
+process.exit(0);

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -1,0 +1,29 @@
+# Plan: <task>
+
+Depth: tree <N>   Mode: orchestrated
+Budget note: <what a competent single pass would take; context, not arithmetic>
+
+## Contract
+
+Decided BEFORE fan-out. Everything a leaf could get wrong about its neighbors:
+
+- Interfaces: <function signatures, file formats, API shapes>
+- Data ownership: <which leaf owns which files; no two leaves share a file>
+- Naming and conventions: <casing, folder layout, error handling style>
+
+## Tree
+
+- 1 <task>
+  - 1.1 <branch> .......... gates/node-1.1.md
+    - 1.1.1 <leaf> ........ gates/leaf-1.1.1.md
+    - 1.1.2 <leaf> ........ gates/leaf-1.1.2.md
+  - 1.2 <branch> .......... gates/node-1.2.md
+    - 1.2.1 <leaf> ........ gates/leaf-1.2.1.md
+    - 1.2.2 <leaf> ........ gates/leaf-1.2.2.md
+
+## Status log
+
+Append-only. One line per event: leaf started, leaf verified, gate abandoned.
+Never rewrite lines above; appending keeps the file cheap to re-read and diff.
+
+- <timestamp or step> plan written, contract fixed

--- a/templates/gates-leaf.md
+++ b/templates/gates-leaf.md
@@ -1,0 +1,27 @@
+# Gates: <leaf or task name>
+
+Scope: <one line: what this unit of work delivers>
+
+- [ ] G1: <observable outcome, stated so a stranger could judge it>
+  CHECK: <shell command that proves it>
+  EXPECT: <substring the command output must contain, or /regex/>
+  EVIDENCE: pending
+
+- [ ] G2: <another runnable outcome>
+  CHECK: <command>
+  EXPECT: <substring or /regex/>
+  EVIDENCE: pending
+
+- [ ] G3: <manual gate, when no command can prove it>
+  EVIDENCE: pending
+
+<!--
+Rules (full spec in references/gates.md):
+- One box per outcome. Boxes are flipped by gate-check.mjs when CHECK output
+  matches EXPECT, or by hand for manual gates.
+- A checked box with EVIDENCE still reading "pending" counts as UNMET.
+- Evidence is the deciding lines only, never a full log.
+- If a gate becomes impossible, do not delete it. Add a line:
+    ABANDON: G<n> <reason>
+  and report it. Visible surrender is honest; silent scope-narrowing is not.
+-->

--- a/templates/gates-node.md
+++ b/templates/gates-node.md
@@ -1,0 +1,29 @@
+# Gates: <branch name> (integration)
+
+Scope: children <list child leaves/branches> merged into one working whole
+
+- [ ] N1: every child leaf's gates file is fully checked (no unchecked boxes, no pending evidence)
+  CHECK: node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-<a>.md gates/leaf-<b>.md
+  EXPECT: ALL MET
+  EVIDENCE: pending
+
+- [ ] N2: interfaces match the contract in PLAN.md
+  CHECK: <build / typecheck / import test command>
+  EXPECT: <success marker>
+  EVIDENCE: pending
+
+- [ ] N3: cross-child behavior works end to end
+  CHECK: <integration test, smoke script, or curl sequence>
+  EXPECT: <success marker>
+  EVIDENCE: pending
+
+- [ ] N4: nothing regressed in siblings this merge touched
+  CHECK: <targeted re-run of affected sibling checks>
+  EXPECT: <success marker>
+  EVIDENCE: pending
+
+<!--
+Branch gates exist because finished parts do not imply a finished whole.
+Do not mark N1 by trusting child reports: re-run their checks yourself
+(verification hierarchy, references/orchestration.md).
+-->


### PR DESCRIPTION
## What this is

v1 fought laziness with instructions. A controlled six-run test (two build tasks x three conditions, independent code review + adversarial verification + live browser testing) showed what instructions buy and what they miss: effort rose 1.6-3.9x and skill runs fixed 4-10 self-found defects before delivery, but the failures that survived were exactly the ones prose cannot catch. Premature done reports, and confidently wrong numbers in final summaries (every skill run had 1-3; baselines had 0). Meanwhile the tree's 2^(N-1) arithmetic never happened: tree 6 cost 1.0-1.5x tree 3, not 8x.

v2's premise: prose cannot enforce prose. Enforcement moves into files and checks.

## The changes

- **Rule zero: gates before work.** Acceptance criteria live in GATES.md / gates/*.md as checkboxes with runnable CHECK/EXPECT lines and mandatory evidence. Done = ledger full.
- **scripts/gate-check.mjs** runs the checks, flips boxes only on match, records capped evidence. Checked-without-evidence counts as unmet.
- **scripts/stop-hook.mjs** (Claude Code, optional): blocks ending the turn while gates are unmet. Progress-aware: counter resets when gate files change, releases after 6 blocked stops without progress, honors ABANDON lines as an honest exit.
- **scripts/install-hooks.mjs**: idempotent install/uninstall (settings.local.json default, --shared, --global).
- **Orchestrated mode** for tree 4+: PLAN.md contract before fan-out, gates per leaf AND per branch, leaves as fresh subagents, parent re-runs each leaf's checks.
- **Report audit rule**: every number in a final report re-measured at report time or labeled unverified.
- **Tree semantics change (breaking)**: depth is decomposition to natural work units; effort per leaf comes from its gates.
- Progressive disclosure: core SKILL.md stays small, references/ load on demand.

## Testing

All script paths exercised by hand on Windows: passing check, failing check, regex EXPECT, manual gate, ABANDON honored, hook block JSON, release-after-6, progress reset, no-gates silent allow, installer install/idempotence/uninstall round trip. Hook API shapes verified against current Claude Code docs (Stop stdin fields, decision/reason contract, 8-block built-in cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)