### PR TITLE
feat: 2.1.0 hardening - validation fixes, --reverify parent verification, self-test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 2.1.0 (2026-08-16)
+
+Hardening pass from a full external validation: the scripts were exercised
+path by path, the README citations were checked against their primary
+sources, and the hook contract was checked against the Claude Code docs.
+
+Fixed:
+
+- `gate-check.mjs` silently dropped a positional file argument at index 0
+  whenever `--timeout` was absent (off-by-one in the argument filter), so
+  `gate-check.mjs gates/leaf-x.md` fell back to default file discovery.
+  Regression-tested in `scripts/verify.mjs`.
+- A passing gate with a CHECK line but no EVIDENCE line flipped its box but
+  stayed unmet forever, because the proof had nowhere to land. gate-check
+  now inserts an EVIDENCE line after the gate's attribute block and keeps
+  later gates' line indices intact.
+- Rewriting a gates file normalized CRLF line endings to LF. Endings are
+  now preserved.
+- The stop hook's progress hash could differ between runs on platforms
+  with different directory listing order; gate files are now read in
+  sorted order in both scripts.
+
+Added:
+
+- `gate-check.mjs --reverify`: re-runs every CHECK command, including gates
+  already marked met, and unchecks any whose evidence does not reproduce.
+  This makes the orchestrated-mode parent step ("verify, never trust")
+  mechanical: forged evidence in a leaf's gates file no longer survives
+  re-verification.
+- CLI validation: unknown flags, `--status` combined with `--reverify`,
+  and invalid `--timeout` values are usage errors (exit 2) instead of
+  silent misbehavior.
+- gate-check warns about unindented `CHECK:` / `EXPECT:` / `EVIDENCE:`
+  lines, which the parsers ignore.
+- Lines inside fenced code blocks are ignored by both parsers, so gate
+  files can embed format examples without them counting as gates.
+- `scripts/verify.mjs`: zero-dependency self-test covering the full
+  CONTRIBUTING matrix plus the regressions above.
+
+Docs:
+
+- The threat model for inherited gate files is now documented in SKILL.md
+  and the README: CHECK lines are executable content, review them before
+  the first gate-check run in a repo you did not write the gates for.
+- The stop-hook's header comment no longer claims an unverified "8
+  consecutive blocks" Claude Code limit; it documents the documented
+  consecutive-block warning behavior instead.
+- `references/gates.md` records the fence and indentation parsing rules;
+  `references/orchestration.md` step 3 now uses `--reverify`.
+
 ## 2.0.0 (2026-08-10)
 
 Enforcement moved from prose into files, checks and an optional hook. Motivated by a controlled six-run test of v1 (two build tasks, three conditions each, independent code review plus adversarial verification plus live browser testing) whose headline results are in the README.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for wanting to improve unlazy. It is a small project on purpose: one skill file, a few references and three zero-dependency scripts. Contributions that keep it small are the easiest to merge.
+Thanks for wanting to improve unlazy. It is a small project on purpose: one skill file, a few references and four zero-dependency scripts. Contributions that keep it small are the easiest to merge.
 
 ## What is welcome
 
@@ -20,4 +20,4 @@ Thanks for wanting to improve unlazy. It is a small project on purpose: one skil
 
 ## How
 
-Open an issue for anything debatable, or a PR directly for anything obvious. There is no build step. For script changes, exercise every path by hand: a gates file with a passing check, a failing check, a regex EXPECT, a manual gate, and an ABANDON line; plus the hook's block, release-after-6, progress-reset and no-gates paths, and the installer's install, idempotence and uninstall round trip.
+Open an issue for anything debatable, or a PR directly for anything obvious. There is no build step. For script changes, exercise every path by hand: a gates file with a passing check, a failing check, a regex EXPECT, a manual gate, and an ABANDON line; plus the hook's block, release-after-6, progress-reset and no-gates paths, and the installer's install, idempotence and uninstall round trip. Or run `node scripts/verify.mjs`, which exercises all of these paths plus the known regressions (dropped positional args, forged evidence, CRLF files, fenced examples), and add a case for whatever you changed.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ node <path-to-skill>/scripts/install-hooks.mjs --uninstall
 
 It is a millisecond file scan, zero tokens per check. If the agent makes no gate progress across six consecutive blocked stops, the hook releases it with a warning instead of trapping it, and an `ABANDON: <gate> <reason>` line is always honored as an honest exit. Add `.unlazy-hook-state.json` to your `.gitignore`.
 
+One safety rule: gate files are executable content. `CHECK:` lines run in your shell. Gates written by you or your agent this session are the intended flow, but a repository you cloned can ship a `GATES.md` or `gates/*.md` of its own, and the first `gate-check` run there would execute whatever those lines contain. Treat inherited gate files like postinstall scripts: read the `CHECK:` lines before the first run in any repo whose gates you did not write.
+
 ### Or let your agent install it
 
 Paste this to Claude Code, Codex, Cursor or any agent with shell access:
@@ -108,7 +110,7 @@ The deeper lesson: prose cannot enforce prose. A model that under-executes instr
 1. **Discipline** (SKILL.md): weakest layer, works in any agent.
 2. **Gates files** (`GATES.md`, `gates/*.md`): intentions written at minute 2 stay sharp at minute 90.
 3. **Runnable checks** (`scripts/gate-check.mjs`): a CHECK command decides, not a feeling of completion.
-4. **Parent re-verification** (orchestrated mode): the dispatcher re-runs each leaf's checks; self-certification is worthless.
+4. **Parent re-verification** (orchestrated mode): the dispatcher re-runs each leaf's checks with `--reverify`; self-certification of runnable gates is worthless.
 5. **The Stop hook** (`scripts/stop-hook.mjs`): ending the turn with unmet gates is blocked, mechanically.
 
 ## How it works
@@ -129,7 +131,7 @@ Before real work starts, the agent writes its acceptance gates to a file:
   EVIDENCE: pending
 ```
 
-`gate-check.mjs` runs the CHECK commands, flips boxes only when EXPECT matches, and records the deciding output lines as evidence. A checked box whose evidence still reads `pending` counts as unmet; a checkbox is a claim, evidence is the proof. Done means the ledger is full, and the final report pastes it, N of N, with every number re-measured at report time.
+`gate-check.mjs` runs the CHECK commands, flips boxes only when EXPECT matches, and records the deciding output lines as evidence. A checked box whose evidence still reads `pending` counts as unmet; a checkbox is a claim, evidence is the proof. Done means the ledger is full, and the final report pastes it, N of N, with every number re-measured at report time. `--reverify` re-runs every CHECK command, including gates already marked met, and unchecks any whose evidence does not reproduce: that is how the driver in orchestrated mode verifies a leaf without trusting its self-report.
 
 For big builds (tree 4+), the tree becomes a real plan: `PLAN.md` holds the contract (interfaces, file ownership, naming, fixed before fan-out), every leaf and branch gets its own gates file, and each leaf runs as a fresh subagent. Fresh context per leaf is the point: the stall-at-80-percent failure is an end-of-long-context disease, and attention, not time, was always the scarce resource.
 
@@ -168,9 +170,11 @@ templates/
   gates-leaf.md                per-leaf gates
   gates-node.md                per-branch integration gates
 scripts/
-  gate-check.mjs               runs CHECK commands, flips boxes, records evidence
+  gate-check.mjs               runs CHECK commands, flips boxes, records evidence;
+                               --reverify re-runs met gates' checks (parent verification)
   stop-hook.mjs                Claude Code Stop hook: blocks stop while gates unmet
   install-hooks.mjs            idempotent hook install/uninstall
+  verify.mjs                   self-test: the full CONTRIBUTING matrix plus regressions
 ```
 
 All scripts are zero-dependency Node 16+, tested on Windows and POSIX shells.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 metadata:
   author: Leonxlnx
   source: https://github.com/Leonxlnx/unlazy
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Unlazy
@@ -27,6 +27,8 @@ node <this-skill-dir>/scripts/gate-check.mjs GATES.md
 ```
 
 Manual gates (no CHECK possible) are checked by hand, but only with the `EVIDENCE:` line replaced by actual proof: a measurement, a quote of output, a file path with the relevant line. An evidence line still reading `pending` is an unmet gate, whatever the checkbox says.
+
+CHECK lines are shell commands, and gate files you did not write this session are untrusted. In a cloned repository that already contains a GATES.md or gates/*.md, read the CHECK lines before running them: inherited gates deserve the same review as postinstall scripts.
 
 If a gate becomes genuinely impossible, do not quietly drop it. Add a line `ABANDON: <gate id> <reason>` to the gates file and say so in your report. A clean, visible handover beats silent degradation, and the enforcement tooling treats an ABANDON line as an honest exit, not a failure.
 

--- a/references/gates.md
+++ b/references/gates.md
@@ -26,7 +26,11 @@ ABANDON: G2 <reason, only if a gate had to be surrendered>
 
 - A gate starts at a line matching `- [ ]` or `- [x]` (case-insensitive x).
 - Indented `CHECK:`, `EXPECT:`, `EVIDENCE:` lines up to the next gate belong
-  to the gate above them.
+  to the gate above them. Unindented attribute lines are ignored, and
+  gate-check reports them as warnings; indent with spaces to attach them.
+- Lines inside fenced code blocks (triple-backtick fences) are ignored by
+  both tools, so a gates file can embed format examples without them
+  counting as gates.
 - `EXPECT:` is a plain substring match against the command's combined
   stdout+stderr, unless wrapped in slashes, then it is a JavaScript regex
   (e.g. `/8\/8 passed/`).

--- a/references/orchestration.md
+++ b/references/orchestration.md
@@ -17,11 +17,13 @@ plan, dispatch, verify, and integrate.
    - its own gates file, verbatim
    - the instruction: work the four passes until every gate is met with
      evidence, then stop; if a gate is impossible, ABANDON it with a reason.
-3. **Verify, never trust.** When the leaf returns, re-run its checks
-   yourself: `node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-x.md`
-   and rerun a spot-check of the CHECK commands. A leaf that checked its own
-   boxes without evidence gets sent back with the specific unmet gates named.
-   This is the layer that makes self-certification worthless.
+3. **Verify, never trust.** When the leaf returns, re-verify it mechanically:
+   `node <skill-dir>/scripts/gate-check.mjs --reverify gates/leaf-x.md`
+   re-runs every CHECK command, including gates the leaf marked met, and
+   unchecks any whose evidence does not reproduce. For runnable gates this
+   makes self-certification worthless; manual gates still need your judgment,
+   so spot-read their evidence lines. A leaf that comes back with demoted
+   gates gets sent back with the specific failures named.
 4. **Log and advance.** Append one line to PLAN.md's status log. Dispatch the
    next leaf. When all children of a branch are verified, work the branch's
    integration gates yourself (or dispatch an integration leaf for it).

--- a/research/findings-unlazy-validation.md
+++ b/research/findings-unlazy-validation.md
@@ -1,0 +1,300 @@
+# Validation findings: unlazy v2.0.0
+
+Validated 2026-08-16, at commit `ed9e8d2` (main). Method: every script
+exercised empirically in sandboxes (pass, fail, regex, manual, ABANDON,
+forged evidence, loop guard, installer round trip); SKILL.md checked
+against the official Claude Code skills and hooks documentation; all 12
+README research citations followed to their primary sources. Reproduction
+commands are inline. House style (hyphens, no em dashes) respected.
+
+## Verdict
+
+The skill is substantially what it claims. The enforcement scripts work
+as documented in every behavior their own CONTRIBUTING test matrix
+covers, the README's research base is real and accurately characterized
+(12 of 12 citations resolve, claims match sources), and the SKILL.md
+follows agent-skills conventions with genuine progressive disclosure.
+Three findings matter beyond cosmetics: one real argument-parsing bug in
+`gate-check.mjs`, one enforcement gap (forged evidence passes every
+layer) that undercuts the README's "self-certification is worthless"
+claim, and one security consideration (gate files are executable content)
+that deserves a documented threat model.
+
+## 1. Empirical script testing
+
+### 1.1 gate-check.mjs: works as specified
+
+Verified on a fixture covering every documented path: substring EXPECT
+pass, substring EXPECT fail, regex EXPECT (`/total: \d+ items/`) pass,
+no-EXPECT gates decided by exit code (both directions), checked-box-with-
+pending-evidence recovered by re-run, checked-with-evidence left alone,
+manual gate without CHECK, ABANDON honored (counted abandoned, not unmet),
+exit codes 0/1/2, evidence capped to the tail two lines at 200 chars,
+second run re-runs only unmet gates. `--timeout 1` against `sleep 5`
+fails cleanly with `ETIMEDOUT`. All as documented in
+[references/gates.md](../references/gates.md) and the script header.
+
+### 1.2 BUG (P1): positional file argument at index 0 is silently dropped
+
+`scripts/gate-check.mjs:23`:
+
+```js
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+```
+
+When `--timeout` is absent, `tIdx` is -1, so `tIdx + 1` is 0 and the
+filter drops `argv` position 0 unconditionally. Reproduced:
+
+```
+$ node gate-check.mjs elsewhere/custom-gates.md
+gate-check: no gate files found (GATES.md or gates/*.md)   # exit 2
+$ node gate-check.mjs --status elsewhere/custom-gates.md
+  UNMET X1 (unchecked): explicit file arg                    # works
+```
+
+Impact: `gate-check.mjs gates/leaf-x.md` (single positional arg, no
+leading flag) silently ignores the named file and falls back to defaults.
+In an orchestrated cwd that means checking every leaf's gates instead of
+one leaf; in a bare cwd it means a spurious exit 2. The documented
+orchestration commands happen to put `--status` first, which is why this
+survived the project's own manual test matrix, which never exercises the
+no-flag positional form. Fix: apply the index exclusion only when
+`tIdx !== -1`, e.g. `i !== (tIdx === -1 ? -2 : tIdx + 1)`.
+
+### 1.3 GAP (P2): forged evidence passes every enforcement layer
+
+A leaf that hand-checks its boxes and hand-writes `EVIDENCE:` lines
+passes `--status` AND a plain re-run, because gates are only re-executed
+when unchecked or evidence-pending (`gate-check.mjs:118`). Reproduced
+with a "lying leaf" file: both invocations report `ALL MET`, exit 0.
+
+This matters because
+[references/orchestration.md](../references/orchestration.md) step 3
+tells the driver to verify via `gate-check.mjs --status gates/leaf-x.md`,
+and the README sells layer 4 of the enforcement hierarchy as "the
+dispatcher re-runs each leaf's checks; self-certification is worthless."
+As shipped, the parent has no mechanical way to re-run a satisfied
+leaf's CHECK commands; it must spot-check by hand, which is prose
+discipline again, the exact thing v2 claims to have moved past. A
+`--reverify` flag that re-executes CHECK commands for all gates
+regardless of checkbox state would close this and make the parent layer
+mechanical. The stop hook has the same property by design (it scans, it
+does not execute), so hard enforcement is hard against laziness but soft
+against deception. That is consistent with the skill's stated threat
+model (quiet incompleteness, not adversarial lying), but the
+orchestration docs overpromise.
+
+### 1.4 Minor parser observations
+
+- Unindented `CHECK:` / `EXPECT:` lines are silently ignored and the gate
+  degrades to manual. A stderr warning would catch format slips.
+- The two parsers use different fallback IDs for gates lacking an `ID:`
+  prefix (`line<N>` in gate-check vs first 24 title chars in stop-hook),
+  so an ABANDON line naming a fallback id can be honored by one tool and
+  not the other. Edge case; only bites id-less gates.
+- `gate-check.mjs:155` rejoins with `\n`, silently normalizing CRLF
+  files to LF on first write. Cosmetic given the Windows claim in the
+  README.
+- Static review of the imports and syntax (optional chaining, no recent
+  APIs) is consistent with the Node 16+ claim; not verified on a Node 16
+  runtime.
+
+### 1.5 stop-hook.mjs: works as specified
+
+Simulated stdin payloads against sandboxes: no gate files allows silently;
+unmet gates emit `{"decision":"block","reason":...}` with exit 0; checked-
+but-pending-evidence counts as unmet; ABANDON lines allow; all-met allows;
+malformed stdin stays permissive (allow). The progress-aware loop guard
+behaves exactly as documented: state hash over combined gate-file content,
+six consecutive no-progress blocks, seventh stop releases with a
+`systemMessage` warning naming the unmet gates. Gate-file edits reset the
+counter. State file `.unlazy-hook-state.json` is written to cwd (README
+says gitignore it).
+
+Contract check against the official hooks reference
+([code.claude.com/docs/en/hooks][hooksref], [hooks guide][hooksguide]):
+stdin `cwd` confirmed; structured stdout with `decision`/`reason` plus
+exit 0 is the documented block mechanism; `systemMessage` is a valid
+universal output field; the settings shape written by the installer
+(`hooks.Stop[].hooks[]{type:"command",command,timeout}`) matches the
+documented schema, no matcher needed for Stop, and `timeout` is per-hook
+seconds (20 set vs 600 default, conservative).
+
+Two deviations from documented best practice, both defensible but worth
+knowing:
+
+- The docs state "Stop hooks receive `stop_hook_active`. The
+  `stop_hook_active` field is true when Claude Code is already continuing
+  as a result of a stop hook" and the common pattern is to allow when it
+  is true. This script ignores it in favor of its own progress-aware
+  counter. That is strictly more capable than the standard one-block
+  pattern (it buys up to six productive blocks), and its own cap bounds
+  the loop, so this is a reasonable design choice, not a bug.
+- The script comment claims "Claude Code additionally force-releases
+  after 8 consecutive blocks". The docs confirm a consecutive-block cap
+  exists ("ends the turn with a warning that the Stop hook blocked too
+  many consecutive times" in the guide) but no number appears in the
+  documentation I could find. Treat "8" as unverified.
+
+### 1.6 install-hooks.mjs: works as specified
+
+Install into `.claude/settings.local.json`, idempotent second run
+(changes nothing), uninstall removes the entry and cleans up empty
+`hooks`/`Stop` keys, leaving `{}`. Refuses to touch invalid JSON. The
+`--global` / `--shared` / default targets are as documented. Output
+tells the user what it does and how to remove it, matching the
+"never install silently" rule in SKILL.md.
+
+## 2. SKILL.md spec compliance
+
+Against [code.claude.com/docs/en/skills][skillsdocs]:
+
+- `name: unlazy` valid; `description` is 538 characters, well under the
+  1,536-character listing truncation, written as what-it-does plus
+  when-to-use with trigger phrases ("/unlazy", "tree N", "gates"),
+  exactly the documented style. `license` accepted; `metadata` is a
+  free-form map so `author`/`source`/`version` are valid, and the
+  frontmatter set is compatible with the stricter six-field packaging
+  subset.
+- Body is 105 lines against the documented "keep SKILL.md under 500
+  lines" guidance; roughly 2.2k tokens. References are 600-900 tokens
+  each and are linked from the core with what/when context, which is the
+  documented progressive-disclosure pattern. The token-economy claims in
+  the skill are consistent with its actual file sizes.
+- One improvement: the docs recommend `${CLAUDE_SKILL_DIR}` when
+  referencing bundled scripts so they resolve and run without permission
+  prompts. SKILL.md uses a `<this-skill-dir>` prose placeholder instead,
+  leaving the agent to infer the absolute path at invocation time.
+  Swapping the placeholder for the variable in the two command examples
+  would make them copy-paste runnable in Claude Code.
+- The README's install instructions via the skills CLI are accurate:
+  `npx skills add <owner>/<repo>` with `-g` and `--all` flags is the
+  documented syntax of [vercel-labs/skills][skillcli], which discovers
+  skills by SKILL.md.
+
+## 3. Citation audit (12 of 12 resolve; claims match)
+
+| README claim | Source | Verdict |
+|---|---|---|
+| Laziness = premature truncation + partial compliance, failures persist under explicit prompting | [arXiv 2512.20662][q-lazy] | Accurate; Dec 19 2025, abstract matches nearly verbatim |
+| Underthinking = abandoning promising lines of thought | [arXiv 2501.18585][underthink] | Accurate; Jan 30 2025 |
+| Overthinking exists; more thinking can hurt | [arXiv 2604.10739][overthink] | Accurate; Apr 12 2026 |
+| Benchmark scoring both at once, "ICLR 2026" | [arXiv 2508.13141][otb] | Paper real and matches; the ICLR 2026 venue is not stated on the arXiv page, unverified |
+| Best agent 14.8%, degradation faster than human repos | [arXiv 2603.24755][slopcode] | Accurate; also: explicit quality guidance cuts verbosity/erosion by a third, which supports this skill's premise |
+| 50%-reliability horizon doubling roughly every four months | [METR Time Horizon 1.1][metr11] | Accurate; Jan 29 2026, 130.8 days ~ 4.3 months (post-2023) |
+| "Measuring AI Ability to Complete Long Tasks" | [arXiv 2503.14499][metrarxiv] | Paper real; exact title is "...Complete Long **Software** Tasks", and the doubling time there is ~7 months since 2019 (the README's four-month figure comes from the newer 1.1 post, so no contradiction, just an imprecise title) |
+| Budget forcing, "Wait" tokens, double-digit math gains | [arXiv 2501.19393][s1] | Accurate; up to 27% over o1-preview, AIME24 50 to 57 percent |
+| LLM pitfalls incl. premature abandonment | [arXiv 2411.09916][giveup] | Accurate; v3 revised Apr 13 2026 |
+| Unified diffs make GPT-4 Turbo 3x less lazy | [aider.chat][aider] | Accurate; 4 vs 12 lazy-comment tasks |
+| Context anxiety; Cognition's Claude Sonnet 4.5 wrapped up early | [Inkeep][inkeep] | Accurate; Oct 3 2025 writeup of Cognition's Devin rebuild |
+| Business press covers model laziness | [Fortune, Jul 28 2026][fortune] | Accurate; headline matches |
+
+A detail worth noticing: the Fortune article's centerpiece anecdote is a
+Claude Code session that "claimed to have processed 80 files when it had
+only opened 11". SKILL.md's "Full files, full lists, full sweeps" rule
+("if the task says all 80 files, the count opened must be 80") reads as
+the direct countermeasure to that exact public incident.
+
+## 4. Security considerations
+
+- **Gate files are executable content.** `gate-check.mjs` runs CHECK
+  lines through a shell (`gate-check.mjs:120`, `shell: true`). In the
+  intended flow the agent writes its own gates, so this is fine. But a
+  foreign repository can ship a `GATES.md` or `gates/*.md`, and the
+  moment a user runs `/unlazy` in that repo the agent will execute
+  whatever those CHECK lines contain, with the user's privileges,
+  before any human review. The stop hook is scan-only by design (good
+  separation), but the docs never tell the user that inherited gate
+  files should be treated like postinstall scripts: read before the
+  first gate-check run in any repo you did not create gates in. This
+  deserves a paragraph in the README's hard-mode section.
+- The hook state file is fail-open (unreadable, corrupt, or hostile JSON
+  all result in allow-or-normal behavior), which is the right failure
+  direction for a productivity hook.
+- The installer writes only deterministic JSON via `JSON.stringify`
+  (no injection surface) and refuses malformed targets.
+
+## 5. Insights
+
+1. **The core design bet is sound and correctly aimed.** The v2 thesis,
+   enforcement in files and subprocesses rather than prose, targets
+   exactly the failures the literature measures: partial compliance
+   under explicit prompting ([arXiv 2512.20662][q-lazy]), long-horizon
+   erosion ([arXiv 2603.24755][slopcode]), and premature wrap-up under
+   perceived context pressure ([Inkeep][inkeep]). The stop hook is the
+   same move as budget forcing ([arXiv 2501.19393][s1]) at the harness
+   layer: suppress the stop signal and the model keeps working.
+2. **The five-layer hierarchy is honest except at layer 4.** Layers 1-3
+   and 5 are mechanical as claimed. Layer 4 (parent re-verification) is
+   half mechanical: the parent can see status but cannot force re-
+   execution, so against a deceptive leaf it degrades to spot-checking
+   by hand. A `--reverify` flag is the single highest-leverage change
+   to make the README's strongest claim true.
+3. **The failure the skill is best at is the one it measured.** The
+   report-audit rule (re-measure every number) plus CHECK-measured
+   numbers for anything that appears in a report attacks the "1-3 wrong
+   numbers per report" finding directly, and the Fortune anecdote shows
+   the failure class is publicly documented, not folklore.
+4. **SlopCodeBench quietly validates the gates format itself.** Its
+   finding that explicit quality guidance cut verbosity and erosion by
+   up to a third without stopping degradation is evidence that prose
+   helps but does not hold, which is precisely the v1-to-v2 lesson the
+   repo derives from its own six-run test. External and internal
+   evidence agree.
+5. **Token economy claims check out on inspection.** Core at ~2.2k
+   tokens, references loaded on demand, checks as subprocesses, capped
+   evidence, append-only logs, and a scan-only hook are all real
+   properties of the artifact, not just documentation claims.
+6. **What I would ship next**, in order: fix the arg off-by-one (1.2);
+  add `--reverify` (1.3); use `${CLAUDE_SKILL_DIR}` in the script
+  invocations (section 2); document the untrusted-gates threat model
+  (section 4); warn on unindented attributes and align the fallback-ID
+  logic between the two parsers (1.4); soften or source the "8
+  consecutive blocks" comment (1.5).
+
+Postscript: five of the six items above shipped as v2.1.0 on 2026-08-16,
+along with CRLF preservation, deterministic (sorted) gate-file reads for
+the hook's progress hash, fenced-example immunity in both parsers, CLI
+usage validation, evidence insertion for gates missing an EVIDENCE line,
+and `scripts/verify.mjs` as the regression harness (33 checks, all
+passing at ship time). Item 3 (`${CLAUDE_SKILL_DIR}`) was implemented and
+then reverted by maintainer preference: the skill's prose stays
+harness-neutral with the original `<skill-dir>` placeholders, at a small
+cost in Claude Code convenience (the agent resolves the path itself
+instead of the harness substituting it). See the CHANGELOG.
+
+## Sources
+
+- [Claude Code hooks reference][hooksref]
+- [Claude Code hooks guide][hooksguide]
+- [Claude Code skills documentation][skillsdocs]
+- [vercel-labs/skills CLI][skillcli]
+- [arXiv 2512.20662, Quantifying Laziness][q-lazy]
+- [arXiv 2501.18585, Thoughts Are All Over the Place][underthink]
+- [arXiv 2604.10739, When More Thinking Hurts][overthink]
+- [arXiv 2508.13141, OptimalThinkingBench][otb]
+- [arXiv 2603.24755, SlopCodeBench][slopcode]
+- [METR Time Horizon 1.1, Jan 2026][metr11]
+- [arXiv 2503.14499, Measuring AI Ability to Complete Long Software Tasks][metrarxiv]
+- [arXiv 2501.19393, s1: Simple test-time scaling][s1]
+- [arXiv 2411.09916, "Should I Give Up Now?"][giveup]
+- [aider.chat, unified diffs][aider]
+- [Inkeep, Context Anxiety][inkeep]
+- [Fortune, Advanced AI models are showing signs of laziness][fortune]
+
+[hooksref]: https://code.claude.com/docs/en/hooks
+[hooksguide]: https://code.claude.com/docs/en/hooks-guide
+[skillsdocs]: https://code.claude.com/docs/en/skills
+[skillcli]: https://github.com/vercel-labs/skills
+[q-lazy]: https://arxiv.org/abs/2512.20662
+[underthink]: https://arxiv.org/abs/2501.18585
+[overthink]: https://arxiv.org/abs/2604.10739
+[otb]: https://arxiv.org/abs/2508.13141
+[slopcode]: https://arxiv.org/abs/2603.24755
+[metr11]: https://metr.org/blog/2026-1-29-time-horizon-1-1/
+[metrarxiv]: https://arxiv.org/abs/2503.14499
+[s1]: https://arxiv.org/abs/2501.19393
+[giveup]: https://arxiv.org/abs/2411.09916
+[aider]: https://aider.chat/docs/unified-diffs.html
+[inkeep]: https://inkeep.com/blog/context-anxiety
+[fortune]: https://fortune.com/2026/07/28/advanced-ai-models-laziness-open-ai-anthropic/

--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -5,6 +5,9 @@
 // Usage:
 //   node gate-check.mjs [file ...]          run unmet gates' checks, update files
 //   node gate-check.mjs --status [file ...] report only, change nothing
+//   node gate-check.mjs --reverify [...]    re-run every CHECK command, including
+//                                           gates already marked met; uncheck any
+//                                           whose evidence does not reproduce
 //   node gate-check.mjs --timeout 60 ...    per-check timeout in seconds (default 120)
 //
 // Files default to GATES.md plus gates/*.md in the current directory.
@@ -15,12 +18,47 @@ import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 
+const USAGE = `usage: gate-check.mjs [--status | --reverify] [--timeout <seconds>] [file ...]
+  --status     report only, change nothing
+  --reverify   re-run every CHECK command, including gates already marked met;
+               uncheck any whose evidence does not reproduce
+  --timeout N  per-check timeout in seconds (default 120, must be > 0)
+Files default to GATES.md plus gates/*.md in the current directory.`;
+
 const args = process.argv.slice(2);
 const statusOnly = args.includes("--status");
+const reverify = args.includes("--reverify");
+
+function usageError(message) {
+  console.error(`gate-check: ${message}`);
+  console.error(USAGE);
+  process.exit(2);
+}
+
+if (statusOnly && reverify) usageError("--status and --reverify are mutually exclusive");
+
+const KNOWN_FLAGS = new Set(["--status", "--reverify", "--timeout"]);
+const unknownFlag = args.find(a => a.startsWith("--") && !KNOWN_FLAGS.has(a));
+if (unknownFlag) usageError(`unknown flag ${unknownFlag}`);
+
 let timeoutSec = 120;
-const tIdx = args.indexOf("--timeout");
-if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+for (let i = 0; i < args.length; i++) {
+  if (args[i] !== "--timeout") continue;
+  const raw = args[i + 1];
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    usageError(`--timeout needs a positive number of seconds, got ${raw === undefined ? "nothing" : JSON.stringify(raw)}`);
+  }
+  timeoutSec = n; // last occurrence wins
+}
+
+// Every value directly following a --timeout occurrence belongs to that flag,
+// never to the file list.
+const timeoutValueIdx = new Set();
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--timeout") timeoutValueIdx.add(i + 1);
+}
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && !timeoutValueIdx.has(i));
 
 function defaultFiles(dir) {
   const found = [];
@@ -28,7 +66,7 @@ function defaultFiles(dir) {
   if (existsSync(top)) found.push(top);
   const gdir = join(dir, "gates");
   if (existsSync(gdir)) {
-    for (const f of readdirSync(gdir)) {
+    for (const f of readdirSync(gdir).sort()) {
       if (f.endsWith(".md")) found.push(join(gdir, f));
     }
   }
@@ -44,15 +82,22 @@ if (!files.length) {
 const GATE_RE = /^- \[( |x|X)\] (.*)$/;
 const ATTR_RE = /^\s+(CHECK|EXPECT|EVIDENCE):\s?(.*)$/;
 const ABANDON_RE = /^ABANDON:\s*(\S+)\s*(.*)$/;
+const FENCE_RE = /^\s*```/;
 
 function parse(lines) {
   const gates = [];
   const abandoned = new Map(); // id -> reason
+  const warnings = [];
   let cur = null;
+  let inFence = false;
   lines.forEach((line, i) => {
+    if (FENCE_RE.test(line)) { inFence = !inFence; return; }
+    if (inFence) return;
     const g = line.match(GATE_RE);
     if (g) {
-      const id = (g[2].match(/^(\S+?):/) || [null, `line${i + 1}`])[1];
+      // Fallback id matches stop-hook.mjs (first 24 chars of the title when no
+      // "ID:" prefix exists) so an ABANDON line resolves the same way in both.
+      const id = (g[2].match(/^(\S+?):/) || [null, g[2].trim().slice(0, 24)])[1];
       cur = {
         line: i, checked: g[1].toLowerCase() === "x",
         title: g[2].trim().replace(/^\S+?:\s*/, ""),
@@ -61,6 +106,9 @@ function parse(lines) {
       };
       gates.push(cur);
       return;
+    }
+    if (/^(CHECK|EXPECT|EVIDENCE):/.test(line)) {
+      warnings.push(`line ${i + 1}: unindented ${line.split(":")[0]} is ignored; indent attribute lines with spaces`);
     }
     const a = cur && line.match(ATTR_RE);
     if (a) {
@@ -73,7 +121,7 @@ function parse(lines) {
     if (ab) abandoned.set(ab[1].replace(/:$/, ""), ab[2] || "(no reason)");
     if (/^#|^- /.test(line) && !g) cur = null;
   });
-  return { gates, abandoned };
+  return { gates, abandoned, warnings };
 }
 
 function expectMatches(expect, output) {
@@ -93,6 +141,7 @@ function tail(output, max = 200) {
 let totalUnmet = 0;
 let totalMet = 0;
 let totalAbandoned = 0;
+let totalReverified = 0;
 
 for (const file of files) {
   let text;
@@ -100,8 +149,10 @@ for (const file of files) {
     console.error(`gate-check: cannot read ${file}: ${e.message}`);
     process.exit(2);
   }
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
   const lines = text.split(/\r?\n/);
-  const { gates, abandoned } = parse(lines);
+  const { gates, abandoned, warnings } = parse(lines);
+  for (const w of warnings) console.error(`gate-check: ${file}: ${w}`);
   if (!gates.length) {
     console.log(`${file}: no gates found`);
     continue;
@@ -111,12 +162,14 @@ for (const file of files) {
   for (const gate of gates) {
     const isAbandoned = abandoned.has(gate.id);
     const pendingEvidence = !gate.evidence || /^pending$/i.test(gate.evidence);
-
     if (isAbandoned) { totalAbandoned++; continue; }
 
-    // Run checks for gates that are unchecked, or checked but missing evidence.
-    const needsRun = !statusOnly && gate.check && (!gate.checked || pendingEvidence);
+    const wasMet = gate.checked && !pendingEvidence;
+    // Run checks for gates that are unchecked, checked but missing evidence,
+    // or (with --reverify) already met: a parent must not trust self-reports.
+    const needsRun = !statusOnly && gate.check && (!gate.checked || pendingEvidence || reverify);
     if (needsRun) {
+      if (reverify && wasMet) totalReverified++;
       const res = spawnSync(gate.check, {
         shell: true, encoding: "utf8", timeout: timeoutSec * 1000,
         maxBuffer: 8 * 1024 * 1024,
@@ -130,6 +183,19 @@ for (const file of files) {
         if (gate.evidenceLine !== -1) {
           const indent = lines[gate.evidenceLine].match(/^\s*/)[0];
           lines[gate.evidenceLine] = `${indent}EVIDENCE: ${tail(output)}`;
+        } else {
+          // A runnable gate with no EVIDENCE line has nowhere to record its
+          // proof; insert one after its attribute block and keep the line
+          // indices of later gates valid.
+          let insertAt = gate.line + 1;
+          while (insertAt < lines.length && ATTR_RE.test(lines[insertAt])) insertAt++;
+          lines.splice(insertAt, 0, `  EVIDENCE: ${tail(output)}`);
+          for (const g2 of gates) {
+            if (g2 === gate) continue;
+            if (g2.line >= insertAt) g2.line++;
+            if (g2.evidenceLine >= insertAt) g2.evidenceLine++;
+          }
+          gate.evidenceLine = insertAt;
         }
         gate.checked = true;
         gate.evidence = tail(output);
@@ -137,7 +203,22 @@ for (const file of files) {
         console.log(`  PASS ${gate.id}: ${gate.title}`);
       } else {
         const why = res.error ? res.error.message : tail(output);
-        console.log(`  FAIL ${gate.id}: ${gate.title}\n       ${why}`);
+        if (reverify && wasMet) {
+          // The recorded evidence does not reproduce: demote the gate back to
+          // unmet. EVIDENCE must read exactly "pending"; both parsers treat
+          // any other value as present evidence.
+          lines[gate.line] = lines[gate.line].replace(/^- \[[xX]\]/, "- [ ]");
+          if (gate.evidenceLine !== -1) {
+            const indent = lines[gate.evidenceLine].match(/^\s*/)[0];
+            lines[gate.evidenceLine] = `${indent}EVIDENCE: pending`;
+          }
+          gate.checked = false;
+          gate.evidence = "pending";
+          changed = true;
+          console.log(`  FAIL ${gate.id}: ${gate.title} (reverify: previously marked met)\n       ${why}`);
+        } else {
+          console.log(`  FAIL ${gate.id}: ${gate.title}\n       ${why}`);
+        }
       }
     }
 
@@ -152,14 +233,20 @@ for (const file of files) {
     }
   }
 
-  if (changed) writeFileSync(file, lines.join("\n"));
+  if (changed) {
+    try { writeFileSync(file, lines.join(eol)); } catch (e) {
+      console.error(`gate-check: cannot write ${file}: ${e.message}`);
+      process.exit(2);
+    }
+  }
   console.log(`${file}: ${gates.length} gates`);
 }
 
+const reverifiedNote = totalReverified ? `, reverified: ${totalReverified}` : "";
 if (totalUnmet === 0) {
-  console.log(`ALL MET (${totalMet} met${totalAbandoned ? `, ${totalAbandoned} abandoned` : ""})`);
+  console.log(`ALL MET (${totalMet} met${totalAbandoned ? `, ${totalAbandoned} abandoned` : ""}${reverifiedNote})`);
   process.exit(0);
 } else {
-  console.log(`UNMET: ${totalUnmet} (met: ${totalMet}${totalAbandoned ? `, abandoned: ${totalAbandoned}` : ""})`);
+  console.log(`UNMET: ${totalUnmet} (met: ${totalMet}${totalAbandoned ? `, abandoned: ${totalAbandoned}` : ""}${reverifiedNote})`);
   process.exit(1);
 }

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -9,14 +9,18 @@
 //   - All gates met or abandoned      -> allow
 //   - Unmet gates, progress happening -> block with a one-line reason
 //   - Unmet gates, NO progress after MAX_BLOCKS consecutive blocks -> allow
-//     with a warning (never traps a genuinely stuck agent; Claude Code
-//     additionally force-releases after 8 consecutive blocks)
+//     with a warning (never traps a genuinely stuck agent; Claude Code also
+//     ends the turn with a warning if a Stop hook blocks too many
+//     consecutive times)
 //
 // Progress = the combined content of the gate files changed since last block.
 // State lives in .unlazy-hook-state.json next to the gates (add to .gitignore).
 //
 // Contract (docs: code.claude.com/docs/en/hooks):
-//   stdin  JSON with { cwd, stop_hook_active, ... }
+//   stdin  JSON with { cwd, stop_hook_active, ... }. stop_hook_active is true
+//          when Claude Code is already continuing because of a stop hook; this
+//          hook deliberately keeps its own progress counter instead of
+//          releasing immediately on that flag, and MAX_BLOCKS bounds the loop.
 //   stdout {"decision":"block","reason":"..."} + exit 0 to block; exit 0 silent to allow.
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
@@ -40,7 +44,9 @@ function gateFiles(dir) {
   const gdir = join(dir, "gates");
   if (existsSync(gdir)) {
     try {
-      for (const f of readdirSync(gdir)) if (f.endsWith(".md")) found.push(join(gdir, f));
+      // Sorted order keeps the combined content hash below deterministic
+      // across platforms and runs.
+      for (const f of readdirSync(gdir).sort()) if (f.endsWith(".md")) found.push(join(gdir, f));
     } catch { /* ignore */ }
   }
   return found;
@@ -71,7 +77,11 @@ for (const file of files) {
     if (!cur.checked || pending) unmet.push(cur.id);
     cur = null;
   };
+  let inFence = false;
   for (const line of lines) {
+    // Fenced code blocks can embed format examples; they are not gates.
+    if (/^\s*```/.test(line)) { inFence = !inFence; continue; }
+    if (inFence) continue;
     const g = line.match(GATE_RE);
     if (g) {
       flush();

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+// verify.mjs : self-test for the unlazy scripts. Zero dependencies. Node 16+.
+//
+// Exercises the full CONTRIBUTING matrix plus known regressions:
+//   gate-check: passing check, failing check, regex EXPECT, manual gate,
+//     ABANDON, --status, --reverify (forged evidence caught, reproducible
+//     evidence passes), usage validation, unindented attributes, CRLF
+//     preservation, per-check timeout, fenced examples ignored, positional
+//     file args at index 0 (regression), missing EVIDENCE lines inserted
+//   stop-hook: no-gates allow, block, ABANDON allow, all-met allow, release
+//     after 6 no-progress blocks, progress reset, malformed stdin, fenced
+//     examples ignored
+//   install-hooks: install, idempotence, uninstall round trip
+//
+// Exit code: 0 = all checks pass, 1 = at least one failure.
+
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const NODE = process.execPath;
+const GATE_CHECK = join(here, "gate-check.mjs");
+const STOP_HOOK = join(here, "stop-hook.mjs");
+const INSTALLER = join(here, "install-hooks.mjs");
+
+let passed = 0;
+const failures = [];
+
+function check(name, cond, detail) {
+  if (cond) { passed++; console.log(`  ok   ${name}`); }
+  else { failures.push(name); console.log(`  FAIL ${name}${detail ? `\n       ${detail}` : ""}`); }
+}
+
+function sandbox(tag) {
+  return mkdtempSync(join(tmpdir(), `unlazy-verify-${tag}-`));
+}
+
+function run(script, argv, opts = {}) {
+  return spawnSync(NODE, [script, ...argv], { encoding: "utf8", timeout: 60000, ...opts });
+}
+
+function gateCheck(argv, cwd) {
+  const r = run(GATE_CHECK, argv, { cwd });
+  return { code: r.status, out: `${r.stdout || ""}${r.stderr || ""}` };
+}
+
+function hook(payload, cwd) {
+  const r = spawnSync(NODE, [STOP_HOOK], { input: payload, encoding: "utf8", timeout: 60000, cwd });
+  return { code: r.status, out: (r.stdout || "").trim() };
+}
+
+console.log("gate-check.mjs");
+
+{
+  const d = sandbox("pass");
+  writeFileSync(join(d, "GATES.md"), [
+    "# Gates: t",
+    "- [ ] G1: echo gate",
+    "  CHECK: echo \"8/8 passed\"",
+    "  EXPECT: 8/8 passed",
+    "  EVIDENCE: pending",
+    "",
+  ].join("\n"));
+  const r = gateCheck(["GATES.md"], d);
+  check("passing check flips box, records evidence, exits 0",
+    r.code === 0 && /PASS G1/.test(r.out) && /ALL MET/.test(r.out), r.out);
+  const after = readFileSync(join(d, "GATES.md"), "utf8");
+  check("file updated with checked box and evidence",
+    after.includes("- [x] G1") && /EVIDENCE: 8\/8 passed/.test(after), after);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("fail");
+  writeFileSync(join(d, "GATES.md"),
+    "- [ ] G1: nope\n  CHECK: echo wrong\n  EXPECT: right\n  EVIDENCE: pending\n");
+  const r = gateCheck(["GATES.md"], d);
+  check("failing check reports FAIL and exits 1",
+    r.code === 1 && /FAIL G1/.test(r.out), r.out);
+  check("failing gate left untouched in file",
+    readFileSync(join(d, "GATES.md"), "utf8").includes("- [ ] G1"));
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("matrix");
+  writeFileSync(join(d, "GATES.md"), [
+    "- [ ] G1: regex",
+    "  CHECK: echo \"total: 42 items\"",
+    "  EXPECT: /total: \\d+ items/",
+    "  EVIDENCE: pending",
+    "- [x] G2: manual with evidence",
+    "  EVIDENCE: file:12 quotes it",
+    "- [ ] G3: manual unmet",
+    "  EVIDENCE: pending",
+    "ABANDON: G3 impossible in fixture",
+    "",
+  ].join("\n"));
+  const before = readFileSync(join(d, "GATES.md"), "utf8");
+  const st = gateCheck(["--status"], d);
+  check("--status reports unmet gates without running or changing anything",
+    st.code === 1 && /UNMET G1/.test(st.out) && readFileSync(join(d, "GATES.md"), "utf8") === before, st.out);
+  const r = gateCheck(["GATES.md"], d);
+  check("regex EXPECT passes; ABANDON counts as an honest exit",
+    r.code === 0 && /PASS G1/.test(r.out) && /1 abandoned/.test(r.out), r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  // Regression: a positional file argument at index 0 was silently dropped
+  // whenever --timeout was absent (off-by-one in the arg filter).
+  const d = sandbox("arg0");
+  mkdirSync(join(d, "elsewhere"));
+  writeFileSync(join(d, "elsewhere", "custom-gates.md"),
+    "- [ ] X1: explicit arg\n  CHECK: echo ok\n  EXPECT: ok\n  EVIDENCE: pending\n");
+  const r = gateCheck(["elsewhere/custom-gates.md"], d);
+  check("regression: positional file arg at index 0 runs the named file",
+    r.code === 0 && /PASS X1/.test(r.out), r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  // Regression: hand-checked boxes with forged evidence passed every layer.
+  const d = sandbox("liar");
+  mkdirSync(join(d, "gates"));
+  writeFileSync(join(d, "gates", "leaf-liar.md"), [
+    "- [x] G1: forged evidence",
+    "  CHECK: echo nope",
+    "  EXPECT: 42/42 passed",
+    "  EVIDENCE: 42/42 passed (forged)",
+    "",
+  ].join("\n"));
+  const plain = gateCheck(["gates/leaf-liar.md"], d);
+  check("precondition: forged evidence still passes a plain run", plain.code === 0, plain.out);
+  const rv = gateCheck(["--reverify", "gates/leaf-liar.md"], d);
+  check("--reverify catches forged evidence",
+    rv.code === 1 && /FAIL G1/.test(rv.out) && /reverify/.test(rv.out), rv.out);
+  const after = readFileSync(join(d, "gates", "leaf-liar.md"), "utf8");
+  check("--reverify demotes the gate to unchecked with pending evidence",
+    after.includes("- [ ] G1") && after.includes("EVIDENCE: pending"), after);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("genuine");
+  writeFileSync(join(d, "GATES.md"), [
+    "- [x] G1: genuinely met",
+    "  CHECK: echo stable-output",
+    "  EXPECT: stable-output",
+    "  EVIDENCE: stable-output",
+    "",
+  ].join("\n"));
+  const rv = gateCheck(["--reverify"], d);
+  check("--reverify keeps reproducible evidence met",
+    rv.code === 0 && /PASS G1/.test(rv.out) && /reverified: 1/.test(rv.out), rv.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("usage");
+  writeFileSync(join(d, "GATES.md"), "- [ ] G1: x\n  EVIDENCE: pending\n");
+  check("--status with --reverify is a usage error", gateCheck(["--status", "--reverify"], d).code === 2);
+  check("unknown flag is a usage error", gateCheck(["--nope"], d).code === 2);
+  check("invalid --timeout value is a usage error", gateCheck(["--timeout", "abc"], d).code === 2);
+  check("zero --timeout is a usage error", gateCheck(["--timeout", "0"], d).code === 2);
+  check("missing --timeout value is a usage error", gateCheck(["--timeout"], d).code === 2);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("indent");
+  writeFileSync(join(d, "GATES.md"), [
+    "- [ ] G1: unindented attrs",
+    "CHECK: echo ok",
+    "EXPECT: ok",
+    "EVIDENCE: pending",
+    "",
+  ].join("\n"));
+  const r = gateCheck(["--status"], d);
+  check("unindented attribute lines warn and are ignored",
+    /unindented/i.test(r.out) && /UNMET G1/.test(r.out), r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("crlf");
+  writeFileSync(join(d, "GATES.md"),
+    "- [ ] G1: crlf file\r\n  CHECK: echo ok\r\n  EXPECT: ok\r\n  EVIDENCE: pending\r\n");
+  const r = gateCheck(["GATES.md"], d);
+  const after = readFileSync(join(d, "GATES.md"), "utf8");
+  check("CRLF line endings are preserved on write",
+    r.code === 0 && after.includes("- [x] G1: crlf file\r\n") && after.includes("EVIDENCE: ok\r\n"), after);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("timeout");
+  writeFileSync(join(d, "GATES.md"), [
+    "- [ ] G1: slow",
+    "  CHECK: node -e \"setTimeout(()=>console.log('done'),5000)\"",
+    "  EXPECT: done",
+    "  EVIDENCE: pending",
+    "",
+  ].join("\n"));
+  const r = gateCheck(["--timeout", "1"], d);
+  check("per-check timeout fails a hanging command",
+    r.code === 1 && /FAIL G1/.test(r.out), r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("fence");
+  writeFileSync(join(d, "GATES.md"), [
+    "# Gates: real",
+    "- [x] G1: real gate",
+    "  EVIDENCE: real",
+    "",
+    "Example format for docs:",
+    "",
+    "```markdown",
+    "- [ ] B1: example gate inside a fence",
+    "  CHECK: echo never-runs",
+    "  EXPECT: never-runs",
+    "  EVIDENCE: pending",
+    "```",
+    "",
+  ].join("\n"));
+  const r = gateCheck(["--status"], d);
+  check("fenced example gates are ignored",
+    r.code === 0 && !/B1/.test(r.out), r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  // Regression: a passing gate with a CHECK line but no EVIDENCE line flipped
+  // its box but could never count as met, because the proof had nowhere to go.
+  const d = sandbox("noev");
+  writeFileSync(join(d, "GATES.md"),
+    "- [ ] G1: no evidence line\n  CHECK: echo ok\n  EXPECT: ok\n");
+  const r = gateCheck(["GATES.md"], d);
+  const after = readFileSync(join(d, "GATES.md"), "utf8");
+  check("passing gate without an EVIDENCE line gets one inserted",
+    r.code === 0 && /EVIDENCE: ok/.test(after), r.out + "\n" + after);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("noev2");
+  writeFileSync(join(d, "GATES.md"), [
+    "- [ ] G1: no evidence line",
+    "  CHECK: echo one",
+    "  EXPECT: one",
+    "- [ ] G2: has evidence line",
+    "  CHECK: echo two",
+    "  EXPECT: two",
+    "  EVIDENCE: pending",
+    "",
+  ].join("\n"));
+  const r = gateCheck(["GATES.md"], d);
+  const after = readFileSync(join(d, "GATES.md"), "utf8");
+  check("evidence insertion keeps later gates' lines intact",
+    r.code === 0 && /PASS G2/.test(r.out) && after.includes("- [x] G1") && after.includes("- [x] G2"),
+    r.out + "\n" + after);
+  rmSync(d, { recursive: true, force: true });
+}
+
+console.log("stop-hook.mjs");
+
+{
+  const d = sandbox("hook-empty");
+  const r = hook(JSON.stringify({ cwd: d }), d);
+  check("no gate files allows silently", r.code === 0 && r.out === "", r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("hook-core");
+  const payload = JSON.stringify({ cwd: d });
+  writeFileSync(join(d, "GATES.md"), [
+    "- [ ] G1: unchecked",
+    "  CHECK: echo ok",
+    "  EXPECT: ok",
+    "  EVIDENCE: pending",
+    "- [x] G2: checked, evidence pending",
+    "  EVIDENCE: pending",
+    "- [x] G3: met",
+    "  EVIDENCE: measured 42",
+    "",
+  ].join("\n"));
+  const blocked = hook(payload, d);
+  let parsed = {};
+  try { parsed = JSON.parse(blocked.out); } catch { /* leave empty */ }
+  check("unmet gates block with decision and reason",
+    blocked.code === 0 && parsed.decision === "block" && /G1, G2/.test(parsed.reason || ""), blocked.out);
+
+  writeFileSync(join(d, "GATES.md"),
+    "- [ ] G1: unchecked\n  EVIDENCE: pending\nABANDON: G1 done enough for the fixture\n");
+  const abandoned = hook(payload, d);
+  check("ABANDON lines allow the stop", abandoned.code === 0 && abandoned.out === "", abandoned.out);
+
+  writeFileSync(join(d, "GATES.md"), "- [x] G1: met\n  EVIDENCE: measured\n");
+  const met = hook(payload, d);
+  check("all gates met allows silently", met.code === 0 && met.out === "", met.out);
+
+  const malformed = hook("not json", d);
+  check("malformed stdin stays permissive", malformed.code === 0 && malformed.out === "", malformed.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("hook-release");
+  const payload = JSON.stringify({ cwd: d });
+  writeFileSync(join(d, "GATES.md"), "- [ ] G1: stuck\n  EVIDENCE: pending\n");
+  let out = "";
+  for (let i = 0; i < 7; i++) out = hook(payload, d).out;
+  let parsed = {};
+  try { parsed = JSON.parse(out); } catch { /* leave empty */ }
+  check("releases with a systemMessage after 6 no-progress blocks",
+    typeof parsed.systemMessage === "string" && /releasing/.test(parsed.systemMessage), out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("hook-progress");
+  const payload = JSON.stringify({ cwd: d });
+  writeFileSync(join(d, "GATES.md"), "- [ ] G1: work\n  EVIDENCE: pending\n");
+  hook(payload, d); // blocks: 1
+  writeFileSync(join(d, "GATES.md"), "- [ ] G1: work\n  EVIDENCE: pending\n\n- notes appended\n");
+  const second = hook(payload, d);
+  const state = JSON.parse(readFileSync(join(d, ".unlazy-hook-state.json"), "utf8"));
+  check("gate-file progress resets the block counter",
+    second.out.includes("\"decision\":\"block\"") && state.blocks === 1,
+    JSON.stringify(state) + " " + second.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+{
+  const d = sandbox("hook-fence");
+  writeFileSync(join(d, "GATES.md"), [
+    "- [x] G1: met",
+    "  EVIDENCE: real",
+    "```markdown",
+    "- [ ] B1: fenced example",
+    "  EVIDENCE: pending",
+    "```",
+    "",
+  ].join("\n"));
+  const r = hook(JSON.stringify({ cwd: d }), d);
+  check("fenced example gates do not block", r.code === 0 && r.out === "", r.out);
+  rmSync(d, { recursive: true, force: true });
+}
+
+console.log("install-hooks.mjs");
+
+{
+  const d = sandbox("installer");
+  const target = join(d, ".claude", "settings.local.json");
+  const i1 = run(INSTALLER, [], { cwd: d });
+  const s1 = JSON.parse(readFileSync(target, "utf8"));
+  const cmd = (s1.hooks && s1.hooks.Stop && s1.hooks.Stop[0].hooks[0].command) || "";
+  check("installs a Stop entry into settings.local.json",
+    i1.status === 0 && cmd.includes("stop-hook.mjs"), JSON.stringify(s1));
+  const i2 = run(INSTALLER, [], { cwd: d });
+  const s2 = JSON.parse(readFileSync(target, "utf8"));
+  check("second install is idempotent",
+    i2.status === 0 && JSON.stringify(s2) === JSON.stringify(s1));
+  const u = run(INSTALLER, ["--uninstall"], { cwd: d });
+  const s3 = JSON.parse(readFileSync(target, "utf8"));
+  check("uninstall removes the entry and cleans up",
+    u.status === 0 && !s3.hooks, JSON.stringify(s3));
+  rmSync(d, { recursive: true, force: true });
+}
+
+console.log(`\n${passed} passed, ${failures.length} failed`);
+if (failures.length) {
+  console.log("failed: " + failures.join(", "));
+  process.exit(1);
+}


### PR DESCRIPTION
## What this is

A hardening pass built on a full external validation of v2.0.0: every script exercised path by path, all README citations followed to primary sources, and the hook contract checked against the Claude Code docs. The validation itself ships as [research/findings-unlazy-validation.md](research/findings-unlazy-validation.md); this PR implements its recommended fixes plus four more robustness issues found along the way.

## Fixed

- **gate-check arg off-by-one (P1)**: a positional file argument at index 0 was silently dropped whenever `--timeout` was absent, so `gate-check.mjs gates/leaf-x.md` fell back to default file discovery (in a bare cwd: a spurious "no gate files found", exit 2). Repro in the validation findings, section 1.2.
- A passing gate with a CHECK line but no EVIDENCE line flipped its box but stayed unmet forever: the proof had nowhere to land. gate-check now inserts an EVIDENCE line after the gate's attribute block, keeping later gates' line indices intact.
- Rewriting a gates file normalized CRLF endings to LF. Endings are preserved (hexdump-verified).
- The stop hook's progress hash could differ between runs on platforms with different directory listing order; both tools now read gate files in sorted order.

## Added

- **`gate-check.mjs --reverify`**: re-runs every CHECK command, including gates already marked met, and unchecks any whose evidence does not reproduce. This closes the validation's P2 gap: a leaf with hand-checked boxes and forged EVIDENCE lines passed every enforcement layer, including `--status`. The orchestrated parent step ("verify, never trust") is now one mechanical command; self-certification of runnable gates counts for nothing.
- CLI validation: unknown flags, `--status` combined with `--reverify`, and invalid `--timeout` values are usage errors (exit 2) with a usage message.
- gate-check warns on unindented `CHECK:`/`EXPECT:`/`EVIDENCE:` lines (which the parsers ignore).
- Lines inside fenced code blocks are ignored by both parsers, so gate files can embed format examples without them counting as gates.
- **`scripts/verify.mjs`**: zero-dependency self-test covering the full CONTRIBUTING matrix plus the regressions above. The repo's own philosophy applied to itself.

## Docs

- Threat model for inherited gate files documented in SKILL.md and README: CHECK lines are executable content, review them before the first gate-check run in a repo you did not write the gates for.
- stop-hook's header comment no longer claims an unverified "8 consecutive blocks" Claude Code limit; it documents the documented consecutive-block warning behavior and the deliberate `stop_hook_active` design choice.
- `references/gates.md` records the fence and indentation parsing rules; `references/orchestration.md` step 3 uses `--reverify`; CHANGELOG 2.1.0; CONTRIBUTING points at verify.mjs.
- Script invocations keep the original harness-neutral `<skill-dir>` / `<this-skill-dir>` placeholders (a `${CLAUDE_SKILL_DIR}` variant was tried and reverted, see edb93d2).

## Verification

```
$ node scripts/verify.mjs
33 passed, 0 failed          # gate-check 22, stop-hook 8, install-hooks 3
```

Both original attack scenarios re-run manually: the dropped-arg repro now executes the named file (exit 0), and the forged-evidence leaf is caught and demoted under `--reverify` (exit 1, box unchecked, EVIDENCE: pending). House style audited: no em dashes, no stale counts, frontmatter within limits.

## Compatibility

No breaking changes. The gate file format is unchanged (the fence and indentation rules formalize what was already undefined territory); every flag that existed in 2.0.0 behaves identically apart from the fixed arg parsing.