### PR TITLE
fix: gate-check drops the first file argument when --timeout is absent

### DIFF
--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -20,7 +20,9 @@ const statusOnly = args.includes("--status");
 let timeoutSec = 120;
 const tIdx = args.indexOf("--timeout");
 if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+// indexOf returns -1 when --timeout is absent, so guard the skip: without this,
+// `i !== tIdx + 1` excludes argv index 0 and swallows the first file argument.
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && (tIdx === -1 || i !== tIdx + 1));
 
 function defaultFiles(dir) {
   const found = [];


### PR DESCRIPTION
## The bug

`indexOf` returns `-1` when `--timeout` is not passed, so the filter condition
`i !== tIdx + 1` becomes `i !== 0` and unconditionally excludes argv index 0.

```js
const tIdx = args.indexOf("--timeout");                       // -1 when absent
const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
```

The first positional file argument is therefore never collected. `fileArgs` comes back
empty, the code falls through to `defaultFiles(process.cwd())`, and the run silently
targets `GATES.md` plus every `gates/*.md` instead of the file that was named.

## Why it matters

It fails quietly rather than loudly: the command still exits 0 or 1 and still prints a
plausible report, so nothing signals that the wrong files were checked.

The path it breaks is load-bearing. `references/orchestration.md` step 3 has the driver
re-run a returning leaf's checks against that leaf's own gates file, which is the layer
that makes leaf self-certification worthless. That documented form happens to survive,
because `--status` occupies index 0 and is dropped by the `startsWith("--")` test anyway:

```
node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-x.md
```

But the bare form in SKILL.md's rule zero does not:

```
node <this-skill-dir>/scripts/gate-check.mjs GATES.md
```

There the fallback happens to include `GATES.md`, so a solo run looks correct while also
running every leaf file present. In orchestrated mode a single leaf verify runs the entire
tree, which is both slow and wrong: it re-runs sibling checks the leaf does not own, and
its verdict reflects the whole project rather than the leaf being verified.

## Reproduction

```
mkdir -p repro/gates && cd repro
printf '# Gates: root\n\n- [ ] R1: root gate\n  CHECK: node -e "console.log(\x27ROOT-RAN\x27)"\n  EXPECT: ROOT-RAN\n  EVIDENCE: pending\n' > GATES.md
printf '# Gates: leaf a\n\n- [ ] A1: leaf a gate\n  CHECK: node -e "console.log(\x27LEAF-A-RAN\x27)"\n  EXPECT: LEAF-A-RAN\n  EVIDENCE: pending\n' > gates/leaf-a.md

node ../scripts/gate-check.mjs gates/leaf-a.md
```

Before, asking for one leaf checks two files:

```
  PASS R1: root gate
  .../repro/GATES.md: 1 gates
  PASS A1: leaf a gate
  .../repro/gates/leaf-a.md: 1 gates
ALL MET (2 met)
```

After:

```
  PASS A1: leaf a gate
gates/leaf-a.md: 1 gates
ALL MET (1 met)
```

`node gate-check.mjs a.md b.md` shows the same defect more directly: `a.md` is dropped and
only `b.md` is checked.

## The fix

Guard the skip on `--timeout` actually being present. One line, no behavior change to any
other path.

```js
const fileArgs = args.filter((a, i) => !a.startsWith("--") && (tIdx === -1 || i !== tIdx + 1));
```

## Verification

Every path CONTRIBUTING.md asks for was exercised by hand, on Windows with Node 24.18.0.
All 17 assertions pass on this branch:

- gate file format: passing check, failing check, regex `EXPECT`, manual gate, `ABANDON` line
- stop hook: block, no gate files, progress reset, release after 6 blocks
- installer: install, idempotence, uninstall round trip

The same suite run against `ed9e8d2` fails exactly two assertions and no others:

```
  FAIL  a single named file is the only file checked
  FAIL  two named files are both checked, neither dropped
  PASS  --timeout still consumes its value and does not eat the file
  PASS  --status with a named file is unaffected (regression guard)
  PASS  no file arguments still defaults to GATES.md plus gates/*.md
```

That is the scope of the change: the two broken paths start working, and `--timeout`,
`--status` and the no-argument default are untouched.

Happy to contribute the verification script if you want it, but it is not included here
since there is no test harness today and CONTRIBUTING says contributions that keep the
project small are easiest to merge.
