### PR TITLE
feat(orchestration): rolling dispatch + parallel gate verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.1.0 (2026-08-21)
+
+Orchestrated mode was too slow because it processed leaves sequentially and re-ran the whole gate tree on every verify pass. Both are fixed, backward compatibly. Single-leaf checkers and solo mode keep the same behavior and exit codes.
+
+New:
+
+- **`gate-check.mjs --jobs <N>`**: max concurrent CHECK executions. Backed by an async `spawn` sliding-window limiter (replaces the blocking `spawnSync` loop). Default 1 = sequential, so existing invocations are unchanged. Bad `--jobs` value exits 2 (usage error), consistent with the existing exit-code contract.
+- **Orchestration: rolling dispatch.** The driver loop in `references/orchestration.md` now launches all ready leaves at once, verifies each scoped to its own gate file (with `--jobs` for batch returns), and immediately dispatches anything a returned leaf unblocks — no lockstep. Parallelism is the default behavior, not an opt-in. Dependencies are explicit via the new PLAN.md fields and never a chain longer than two.
+- **`templates/PLAN.md` readiness tracking.** Tree entries now carry `State` (READY / IN-FLIGHT / VERIFIED / ABANDONED) and `Needs` (leaf ids that must be Verified before this leaf dispatches). The status log gains a monotonic step counter and mandated event types (dispatched / verified / abandoned / branch-integrated).
+
+Kept unchanged: `scripts/stop-hook.mjs` (its global gate scan is correct for an exit gate, even though per-leaf verification is now scoped), `scripts/install-hooks.mjs`, `references/{method,gates,token-economy}.md`, all gate-file formats, exit codes.
+
 ## 2.0.0 (2026-08-10)
 
 Enforcement moved from prose into files, checks and an optional hook. Motivated by a controlled six-run test of v1 (two build tasks, three conditions each, independent code review plus adversarial verification plus live browser testing) whose headline results are in the README.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 metadata:
   author: Leonxlnx
   source: https://github.com/Leonxlnx/unlazy
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Unlazy

--- a/references/orchestration.md
+++ b/references/orchestration.md
@@ -4,37 +4,92 @@ For tree depth 4+ or any build clearly beyond one sitting. The core insight:
 the stall-at-80-percent failure is an end-of-long-context disease. Attention,
 not time, is the scarce resource, and a fresh subagent per leaf resets it.
 
-## The driver loop
+## The driver loop (rolling dispatch)
 
 You (the main session) are the driver. You do not implement leaves; you
-plan, dispatch, verify, and integrate.
+plan, dispatch, verify, and integrate. The loop is rolling, not lockstep:
+leaves with no unmet dependencies are launched together, and each leaf that
+returns and passes verification gates the dispatch of whatever it unblocks.
+
+The contract in PLAN.md guarantees disjoint file ownership, so ready leaves
+never contend on shared files. If two leaves ever need the same file, fix
+the plan, do not coordinate through hope.
 
 1. **Plan.** Write PLAN.md (contract, tree, gates file per leaf and branch)
    from templates/PLAN.md. This is the only step where the whole task must
-   fit in one head.
-2. **Dispatch one leaf.** Spawn a subagent whose entire brief is:
+   fit in one head. Mark every leaf's initial State as READY (or BLOCKED
+   with the leaf it waits on in the Needs field) before dispatch begins.
+
+2. **Dispatch all ready leaves.** A leaf is ready when its State is READY
+   and every leaf in its Needs field is already Verified. Launch a subagent
+   for *each* ready leaf, not just one. Each subagent's entire brief is:
    - the contract section of PLAN.md (not the whole file, not your history)
    - its own gates file, verbatim
    - the instruction: work the four passes until every gate is met with
      evidence, then stop; if a gate is impossible, ABANDON it with a reason.
-3. **Verify, never trust.** When the leaf returns, re-run its checks
-   yourself: `node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-x.md`
-   and rerun a spot-check of the CHECK commands. A leaf that checked its own
-   boxes without evidence gets sent back with the specific unmet gates named.
-   This is the layer that makes self-certification worthless.
-4. **Log and advance.** Append one line to PLAN.md's status log. Dispatch the
-   next leaf. When all children of a branch are verified, work the branch's
-   integration gates yourself (or dispatch an integration leaf for it).
+
+   Update each dispatched leaf's State from READY to IN-FLIGHT in PLAN.md.
+
+3. **Verify each leaf on return, never trust.** As each leaf returns, re-run
+   its checks yourself against its specific file (scoped, not the whole tree):
+   ```
+   node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-x.md
+   ```
+   For faster verification when several leaves return around the same time,
+   pass multiple files and raise concurrency:
+   ```
+   node <skill-dir>/scripts/gate-check.mjs --jobs 4 --status gates/leaf-a.md gates/leaf-b.md
+   ```
+   Also rerun a spot-check of the CHECK commands by hand. A leaf that checked
+   its own boxes without evidence gets sent back with the specific unmet
+   gates named. This is the layer that makes self-certification worthless.
+
+4. **Log and advance.** Append one line to PLAN.md's status log for the
+   returned leaf. Flip its State to VERIFIED (or ABANDONED). Then look at
+   every remaining BLOCKED leaf: if all the leaves in its Needs field are
+   now VERIFIED, flip it to READY and immediately dispatch it (step 2). Do
+   not wait for the rest of the in-flight batch. When all children of a
+   branch are verified, work the branch's integration gates yourself (or
+   dispatch an integration leaf for it).
+
 5. **Report.** Only when the root's gates are met. Paste the ledger, N of N,
    with every ABANDON line surfaced, and re-measure every number you state.
 
-## Parallelism
+## The rolling loop, as a loop
 
-Leaves whose file ownership is disjoint (the contract guarantees this) can
-run concurrently if the harness supports parallel subagents. Parallelism
-buys wall-clock time, not token savings; do not use it as an excuse to skip
+Read steps 2-4 as a loop, not a sequence you finish once:
+
+```
+while unverified leaves remain:
+    dispatch every READY leaf you have not yet launched
+    wait for the next leaf to return
+    verify it (scoped gate-check, --jobs for batch returns)
+    log the result; set its State in PLAN.md
+    scan BLOCKED leaves; promote any now-unblocked to READY
+    -> back to while-condition
+```
+
+The point: the wall-clock cost of a leaf that finishes early should not be
+paid waiting for a sibling that finishes late. A leaf that returns and
+unblocks a dependent should get that dependent running before you finish
+your coffee, not after the rest of the batch.
+
+## Parallelism and dependencies
+
+Leaves whose file ownership is disjoint (the contract guarantees this) run
+concurrently — that is now the default behavior of the dispatch step, not
+an optional mode you have to remember to enable. Parallelism buys
+wall-clock time, not token savings; do not use it as an excuse to skip
 per-leaf verification. If two leaves ever need the same file, fix the plan,
 do not coordinate through hope.
+
+Dependencies are the exception to "launch all ready leaves now": a leaf is
+not ready until every leaf named in its Needs field is Verified. Encode
+dependencies in PLAN.md at plan time, not at dispatch time. Prefer zero
+dependencies (split so leaves are independent); when a dependency is
+unavoidable, make it a single-leaf dependency, never a chain longer than
+two, because every link in a chain is an earlier wall-clock finish you give
+up to sequentiality.
 
 ## Verification hierarchy
 
@@ -43,11 +98,13 @@ misses:
 
 1. **Leaf self-check**: gate-check run by the leaf itself. Catches honest
    incompleteness, misses self-deception.
-2. **Parent re-run**: the driver re-executes the checks. Catches
-   self-deception and environment differences.
+2. **Parent re-run**: the driver re-executes the checks, scoped to the
+   leaf's own gates file. Catches self-deception and environment
+   differences.
 3. **Stop-hook** (Claude Code, optional): structurally blocks a session from
    ending while gates are unmet. Catches the driver itself drifting into
-   report mode.
+   report mode. It scans all gate files globally — correct for an exit
+   gate, even though per-leaf verification is scoped.
 
 Prose discipline is layer zero and it is the weakest; that is the lesson v2
 is built on. Prefer moving any repeated judgment call up this hierarchy:

--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -6,13 +6,15 @@
 //   node gate-check.mjs [file ...]          run unmet gates' checks, update files
 //   node gate-check.mjs --status [file ...] report only, change nothing
 //   node gate-check.mjs --timeout 60 ...    per-check timeout in seconds (default 120)
+//   node gate-check.mjs --jobs 4 ...        max concurrent checks (default 1 = sequential)
 //
-// Files default to GATES.md plus gates/*.md in the current directory.
+// Files default to GATES.md plus gates/*.md in the current directory. For
+// orchestrated mode, pass explicit leaf files so only that leaf is checked.
 // Exit codes: 0 = all gates met (or honestly abandoned), 1 = unmet gates remain,
 //             2 = usage or parse error.
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { join } from "node:path";
 
 const args = process.argv.slice(2);
@@ -20,7 +22,16 @@ const statusOnly = args.includes("--status");
 let timeoutSec = 120;
 const tIdx = args.indexOf("--timeout");
 if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+let jobs = 1;
+const jIdx = args.indexOf("--jobs");
+if (jIdx !== -1) {
+  const n = Number(args[jIdx + 1]);
+  if (Number.isInteger(n) && n >= 1) jobs = n;
+  else { console.error("gate-check: --jobs requires a positive integer"); process.exit(2); }
+}
+// File args are positional args that are not the value following --timeout/--jobs.
+const skipValueIdx = new Set([tIdx + 1, jIdx + 1].filter(i => i >= 0 && i < args.length));
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx && i !== jIdx && !skipValueIdx.has(i));
 
 function defaultFiles(dir) {
   const found = [];
@@ -58,6 +69,7 @@ function parse(lines) {
         title: g[2].trim().replace(/^\S+?:\s*/, ""),
         id,
         check: null, expect: null, evidence: null, evidenceLine: -1,
+        file: null,
       };
       gates.push(cur);
       return;
@@ -90,10 +102,74 @@ function tail(output, max = 200) {
   return (last || "(no output)").slice(0, max);
 }
 
+// ---------------------------------------------------------------------------
+// Async execution with a concurrency limiter. Replaces the old synchronous
+// spawnSync loop: checks now run concurrently up to --jobs at a time, which
+// turns a wall-clock-long sequential verify into a fast parallel one. Output
+// is buffered per-process and resolved via Promise.all.
+// ---------------------------------------------------------------------------
+
+function runCheck(cmd, timeoutMs) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, { shell: true, encoding: "utf8" });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      try { child.kill("SIGKILL"); } catch {}
+      if (!settled) {
+        settled = true;
+        resolve({ stdout, stderr, status: null, error: { message: "timeout" } });
+      }
+    }, timeoutMs);
+
+    child.stdout.on("data", (d) => { stdout += d; });
+    child.stderr.on("data", (d) => { stderr += d; });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      if (!settled) { settled = true; resolve({ stdout, stderr, status: null, error: err }); }
+    });
+    child.on("close", (status) => {
+      clearTimeout(timer);
+      if (!settled) { settled = true; resolve({ stdout, stderr, status, error: null }); }
+    });
+    child.on("exit", (status) => {
+      clearTimeout(timer);
+      if (!settled) { settled = true; resolve({ stdout, stderr, status, error: null }); }
+    });
+  });
+}
+
+async function runAll(pendingChecks, jobs) {
+  // Sliding-window concurrency: launch up to `jobs` simultaneously.
+  const results = new Array(pendingChecks.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const myIdx = next++;
+      if (myIdx >= pendingChecks.length) return;
+      results[myIdx] = await runCheck(pendingChecks[myIdx].gate.check, timeoutSec * 1000);
+    }
+  }
+  const workers = [];
+  const n = Math.min(jobs, pendingChecks.length || 1);
+  for (let i = 0; i < n; i++) workers.push(worker());
+  await Promise.all(workers);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main: gather gate files, parse, build the list of gates needing a check,
+// run checks concurrently, then apply results (flip boxes, write evidence),
+// and tally.
+// ---------------------------------------------------------------------------
+
 let totalUnmet = 0;
 let totalMet = 0;
 let totalAbandoned = 0;
 
+// Load and parse every file first.
+const fileData = [];
 for (const file of files) {
   let text;
   try { text = readFileSync(file, "utf8"); } catch (e) {
@@ -102,34 +178,49 @@ for (const file of files) {
   }
   const lines = text.split(/\r?\n/);
   const { gates, abandoned } = parse(lines);
-  if (!gates.length) {
-    console.log(`${file}: no gates found`);
-    continue;
+  for (const g of gates) g.file = file;
+  fileData.push({ file, lines, gates, abandoned });
+  if (!gates.length) console.log(`${file}: no gates found`);
+}
+
+// Collect every gate that actually needs a monitor run across all files,
+// preserving order so the results array lines up.
+const pendingChecks = [];
+for (const fd of fileData) {
+  for (const gate of fd.gates) {
+    const isAbandoned = fd.abandoned.has(gate.id);
+    const pendingEvidence = !gate.evidence || /^pending$/i.test(gate.evidence);
+    if (isAbandoned) continue; // abandoned gates resolved below
+    const needsRun = !statusOnly && gate.check && (!gate.checked || pendingEvidence);
+    if (needsRun) pendingChecks.push({ gate });
   }
+}
+
+// Run them concurrently (or sequentially when jobs=1).
+const checkResults = await runAll(pendingChecks, jobs);
+let resultPtr = 0;
+
+for (const fd of fileData) {
   let changed = false;
 
-  for (const gate of gates) {
-    const isAbandoned = abandoned.has(gate.id);
-    const pendingEvidence = !gate.evidence || /^pending$/i.test(gate.evidence);
-
+  for (const gate of fd.gates) {
+    const isAbandoned = fd.abandoned.has(gate.id);
     if (isAbandoned) { totalAbandoned++; continue; }
 
-    // Run checks for gates that are unchecked, or checked but missing evidence.
+    const pendingEvidence = !gate.evidence || /^pending$/i.test(gate.evidence);
     const needsRun = !statusOnly && gate.check && (!gate.checked || pendingEvidence);
+
     if (needsRun) {
-      const res = spawnSync(gate.check, {
-        shell: true, encoding: "utf8", timeout: timeoutSec * 1000,
-        maxBuffer: 8 * 1024 * 1024,
-      });
+      const res = checkResults[resultPtr++];
       const output = `${res.stdout || ""}\n${res.stderr || ""}`;
       // With an EXPECT, the match decides (a check may exit non-zero by design);
       // without one, the exit code decides.
       const ok = gate.expect ? expectMatches(gate.expect, output) : res.status === 0;
       if (ok) {
-        lines[gate.line] = lines[gate.line].replace(/^- \[ \]/, "- [x]");
+        fd.lines[gate.line] = fd.lines[gate.line].replace(/^- \[ \]/, "- [x]");
         if (gate.evidenceLine !== -1) {
-          const indent = lines[gate.evidenceLine].match(/^\s*/)[0];
-          lines[gate.evidenceLine] = `${indent}EVIDENCE: ${tail(output)}`;
+          const indent = fd.lines[gate.evidenceLine].match(/^\s*/)[0];
+          fd.lines[gate.evidenceLine] = `${indent}EVIDENCE: ${tail(output)}`;
         }
         gate.checked = true;
         gate.evidence = tail(output);
@@ -152,8 +243,8 @@ for (const file of files) {
     }
   }
 
-  if (changed) writeFileSync(file, lines.join("\n"));
-  console.log(`${file}: ${gates.length} gates`);
+  if (changed) writeFileSync(fd.file, fd.lines.join("\n"));
+  console.log(`${fd.file}: ${fd.gates.length} gates`);
 }
 
 if (totalUnmet === 0) {

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -13,17 +13,35 @@ Decided BEFORE fan-out. Everything a leaf could get wrong about its neighbors:
 
 ## Tree
 
+State is one of READY, IN-FLIGHT, VERIFIED, ABANDONED. Update it in-place as
+the driver dispatches and verifies; the status log below is append-only but
+the State column here is mutable so the driver can scan readiness at a glance.
+
+Needs lists the leaf ids that must be Verified before this leaf can dispatch.
+Leave empty (or "-") for independent leaves; dependencies are the exception,
+not the rule — prefer zero.
+
 - 1 <task>
-  - 1.1 <branch> .......... gates/node-1.1.md
-    - 1.1.1 <leaf> ........ gates/leaf-1.1.1.md
-    - 1.1.2 <leaf> ........ gates/leaf-1.1.2.md
-  - 1.2 <branch> .......... gates/node-1.2.md
-    - 1.2.1 <leaf> ........ gates/leaf-1.2.1.md
-    - 1.2.2 <leaf> ........ gates/leaf-1.2.2.md
+  - 1.1 <branch> .......... gates/leaf-1.1.md          Needs: -          State: READY
+    - 1.1.1 <leaf> ........ gates/leaf-1.1.1.md        Needs: -          State: READY
+    - 1.1.2 <leaf> ........ gates/leaf-1.1.2.md        Needs: -          State: READY
+  - 1.2 <branch> .......... gates/leaf-1.2.md          Needs: -          State: READY
+    - 1.2.1 <leaf> ........ gates/leaf-1.2.1.md        Needs: -          State: READY
+    - 1.2.2 <leaf> ........ gates/leaf-1.2.2.md        Needs: 1.2.1      State: BLOCKED
 
 ## Status log
 
-Append-only. One line per event: leaf started, leaf verified, gate abandoned.
-Never rewrite lines above; appending keeps the file cheap to re-read and diff.
+Append-only. One line per event. The State column above is the live snapshot;
+this log is the history, so you can reconstruct what happened and when.
 
-- <timestamp or step> plan written, contract fixed
+Mandated events to log:
+- leaf dispatched:  "<step> <leaf-id> dispatched"
+- leaf verified:   "<step> <leaf-id> verified (<N>/<N> gates met)"
+- leaf abandoned:   "<step> <leaf-id> abandoned: <which gates, why>"
+- branch integrated: "<step> <branch-id> integration gates met"
+
+Never rewrite lines above; appending keeps the file cheap to re-read and diff.
+The step counter is monotonic (starts at 1, steps every event regardless of
+which leaf) so any two log lines can be compared for ordering.
+
+- 1 plan written, contract fixed


### PR DESCRIPTION
## Summary

Orchestrated mode was too slow because it processed leaves sequentially and re-ran the whole gate tree on every verify pass. Both are fixed, backward compatibly. Single-leaf checkers and solo mode keep the same behavior and exit codes.

`gate-check.mjs --jobs <N>`: max concurrent CHECK executions. Backed by an async `spawn` sliding-window limiter (replaces the blocking `spawnSync` loop). Default 1 = sequential, so existing invocations are unchanged. Bad `--jobs` value exits 2 (usage error).

**Orchestration: rolling dispatch.** The driver loop in `references/orchestration.md` now launches all ready leaves at once, verifies each scoped to its own gate file (with `--jobs` for batch returns), and immediately dispatches anything a returned leaf unblocks — no lockstep. Parallelism is the default behavior, not an opt-in. Dependencies are explicit via the new PLAN.md fields and never a chain longer than two.

**`templates/PLAN.md` readiness tracking.** Tree entries now carry `State` (READY / IN-FLIGHT / VERIFIED / ABANDONED) and `Needs` (leaf ids that must be Verified before this leaf dispatches). The status log gains a monotonic step counter and mandated event types (dispatched / verified / abandoned / branch-integrated).

Kept unchanged: `scripts/stop-hook.mjs`, `scripts/install-hooks.mjs`, `references/{method,gates,token-economy}.md`, all gate-file formats, exit codes.

## Changelog (2.1.0 / 2026-08-21)

Orchestrated mode was too slow because it processed leaves sequentially and re-ran the whole gate tree on every verify pass. Both are fixed, backward compatibly. Single-leaf checkers and solo mode keep the same behavior and exit codes.

New:

- **`gate-check.mjs --jobs <N>`**: max concurrent CHECK executions. Backed by an async `spawn` sliding-window limiter (replaces the blocking `spawnSync` loop). Default 1 = sequential, so existing invocations are unchanged. Bad `--jobs` value exits 2 (usage error), consistent with the existing exit-code contract.
- **Orchestration: rolling dispatch.** The driver loop in `references/orchestration.md` now launches all ready leaves at once, verifies each scoped to its own gate file (with `--jobs` for batch returns), and immediately dispatches anything a returned leaf unblocks — no lockstep. Parallelism is the default behavior, not an opt-in. Dependencies are explicit via the new PLAN.md fields and never a chain longer than two.
- **`templates/PLAN.md` readiness tracking.** Tree entries now carry `State` (READY / IN-FLIGHT / VERIFIED / ABANDONED) and `Needs` (leaf ids that must be Verified before this leaf dispatches). The status log gains a monotonic step counter and mandated event types (dispatched / verified / abandoned / branch-integrated).

Kept unchanged: `scripts/stop-hook.mjs` (its global gate scan is correct for an exit gate, even though per-leaf verification is now scoped), `scripts/install-hooks.mjs`, `references/{method,gates,token-economy}.md`, all gate-file formats, exit codes.

## Test plan

- [ ] `node --check scripts/gate-check.mjs` (syntax)
- [ ] Smoke run on a synthetic GATES.md with three gates: --jobs 1, --jobs 2, --jobs 3, all pass-fail-mix
- [ ] Bad `--jobs` value exits 2
- [ ] `--status` mode leaves files untouched, exits 0 if anything unmet, 0 if all met
- [ ] Verify rolling dispatch on a 4-leaf PLAN where one leaf depends on another
