### PR TITLE
fix(gate-check): stop dropping the first positional gate file argument

### DIFF
--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -20,7 +20,8 @@ const statusOnly = args.includes("--status");
 let timeoutSec = 120;
 const tIdx = args.indexOf("--timeout");
 if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+const tValIdx = tIdx === -1 ? -1 : tIdx + 1; // --timeout's value is not a file
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tValIdx);
 
 function defaultFiles(dir) {
   const found = [];


### PR DESCRIPTION
## Problem

`gate-check.mjs` silently ignores an explicit gate file passed as the first
argument and falls back to scanning `GATES.md` plus every `gates/*.md` in the
working directory. It then executes every sibling leaf's CHECK commands, with
their side effects, and flips sibling boxes.

This matters most in the skill's own orchestrated mode. A leaf subagent gets a
narrow brief and its own gates file, so `node gate-check.mjs gates/leaf3.md` is
the normal invocation. Today that run touches all the other leaves.

The bug hides in most documented invocations. `--status gates/leaf1.md`
(`references/orchestration.md:21`, `templates/gates-node.md:6`) works because
argv index 0 is a `--` flag that the filter had already removed. `node
gate-check.mjs GATES.md` (`SKILL.md:26`) only appears to work because the
fallback scan happens to include `GATES.md`.

## Cause

One line, `scripts/gate-check.mjs:23`:

```js
const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
```

`tIdx` is `args.indexOf("--timeout")`. When `--timeout` is absent `tIdx === -1`,
so `tIdx + 1 === 0`, so argv index 0 is dropped unconditionally.

## Reproduction

Fixture: a `GATES.md` with 6 gates (one of whose CHECK commands writes
`root-check-ran.txt`, one failing CHECK, a regex EXPECT, a manual gate, an
`ABANDON:` line) plus `gates/leaf1.md` and `gates/leaf2.md` with one gate each.

Before, asking for `gates/leaf1.md` only (paths shortened to the fixture root;
the fallback prints absolute paths because `defaultFiles` joins `process.cwd()`,
which is itself a tell, and the box lists below are condensed to one line):

```
$ node gate-check.mjs gates/leaf1.md
  PASS G1: passing check, substring EXPECT
  PASS G2: passing check, regex EXPECT
  FAIL G3: failing check, exit code decides
       boom
  PASS G5: check with a side effect, proves execution
GATES.md: 6 gates
  PASS L1: leaf1 check runs and passes
gates/leaf1.md: 1 gates
gates/leaf2.md: 1 gates
UNMET: 3 (met: 4, abandoned: 1)
exit=1

$ ls *.txt
leaf1-check-ran.txt   root-check-ran.txt      <-- sibling CHECK side effect
$ grep '^- \[' GATES.md
- [x] G1: ...   - [x] G2: ...   - [x] G5: ...  <-- sibling boxes flipped
```

After:

```
$ node gate-check.mjs gates/leaf1.md
  PASS L1: leaf1 check runs and passes
gates/leaf1.md: 1 gates
ALL MET (1 met)
exit=0

$ ls *.txt
leaf1-check-ran.txt
$ grep '^- \[' GATES.md
- [ ] G1 ... - [ ] G2 ... - [ ] G3 ... - [ ] G4 ... - [ ] G5 ... - [ ] G6
```

## Fix

```diff
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+const tValIdx = tIdx === -1 ? -1 : tIdx + 1; // --timeout's value is not a file
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tValIdx);
```

Two lines, no dependency, no restructuring, Node 16+ standard library only. The
gate file format is untouched, so the spec, the other script and the templates
need no change.

## Manual test matrix

Fixture rebuilt from scratch before every run. `markers` lists the files written
by CHECK side effects, which is how "did a sibling check run" is observed.

| command | output | exit | markers |
| --- | --- | --- | --- |
| `gate-check.mjs` | GATES.md 6 gates, leaf1 1, leaf2 1, `UNMET: 3 (met: 4, abandoned: 1)` | 1 | leaf1, root |
| `gate-check.mjs gates/leaf1.md` | `PASS L1`, `gates/leaf1.md: 1 gates`, `ALL MET (1 met)` | 0 | leaf1 only |
| `gate-check.mjs GATES.md gates/leaf1.md` | both files scanned, `UNMET: 2 (met: 4, abandoned: 1)` | 1 | leaf1, root |
| `gate-check.mjs GATES.md` | `GATES.md: 6 gates`, `UNMET: 2 (met: 3, abandoned: 1)`, leaf boxes untouched | 1 | root only |
| `gate-check.mjs --status gates/leaf1.md` | `UNMET L1 (unchecked)`, leaf1 only | 1 | none, nothing executed |
| `gate-check.mjs --status` | all 3 files listed, `UNMET: 7 (met: 0, abandoned: 1)` | 1 | none |
| `gate-check.mjs --timeout 60 gates/leaf1.md` | `PASS L1`, leaf1 only, `ALL MET (1 met)` | 0 | leaf1 only |
| `gate-check.mjs gates/leaf1.md --timeout 60` | `PASS L1`, leaf1 only, `ALL MET (1 met)` | 0 | leaf1 only |
| `gate-check.mjs` in a dir with no gate files | `gate-check: no gate files found (GATES.md or gates/*.md)` | 2 | none |
| `gate-check.mjs --status` in a dir with no gate files | same message | 2 | none |
| `gate-check.mjs gates/nope.md` | `gate-check: cannot read gates/nope.md: ENOENT...` | 2 | none |

`60` is never treated as a file in either `--timeout` position, and no run
reports a `60: ...` line or an ENOENT for it.

Gate paths covered by the fixture: passing CHECK with substring EXPECT, passing
CHECK with `/regex/` EXPECT, failing CHECK decided by exit code, manual gate with
no CHECK, CHECK with an observable side effect, and an `ABANDON:` line (reported
as abandoned, never run).

## Stop hook not regressed

`stop-hook.mjs` is untouched. Verified anyway:

```
$ echo '{"cwd":"<fixture>"}' | node scripts/stop-hook.mjs
{"decision":"block","reason":"unlazy: 7 gate(s) unmet: G1, G2, G3, G4, G5, +2 more. ..."}
exit=0

$ echo '{"cwd":"<empty dir>"}' | node scripts/stop-hook.mjs      # allow, silent
exit=0

$ echo '{"cwd":"<all met dir>"}' | node scripts/stop-hook.mjs    # allow, silent
exit=0
```

Release-after-6 and progress-reset also re-run: stops 1 to 6 block, stop 7 emits
`unlazy: releasing after 6 blocks without gate progress; 7 gates remain unmet`,
and a gate-file edit resets the counter to `{"hash":"...","blocks":1}`.
