### PR TITLE
fix: gate-check drops the first file argument when --timeout is absent

### DIFF
--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -20,7 +20,7 @@ const statusOnly = args.includes("--status");
 let timeoutSec = 120;
 const tIdx = args.indexOf("--timeout");
 if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && !(tIdx !== -1 && i === tIdx + 1));
 
 function defaultFiles(dir) {
   const found = [];


### PR DESCRIPTION
## The bug

`scripts/gate-check.mjs:23`

```js
const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
```

`tIdx` is `args.indexOf("--timeout")`, so it is `-1` whenever the flag is not passed, and `tIdx + 1` is `0`. The filter then excludes index 0 on every run without `--timeout`: the first file argument is silently discarded.

`fileArgs` comes out empty, `files` falls back to `defaultFiles(process.cwd())`, and the run quietly widens to every gate file in the directory.

## Reproduce

`gates/a.md` and `gates/b.md`, both with one unchecked gate:

```
$ node gate-check.mjs gates/a.md
  FAIL G1: sempre falha
       NOPE
.../gates/a.md: 1 gates
  PASS G2: passa
.../gates/b.md: 1 gates
UNMET: 1 (met: 1)
```

`gates/b.md` was not named on the command line, but its check ran and its box and EVIDENCE line were rewritten on disk. Naming one leaf's gate file executes and mutates its siblings.

`--status gates/a.md gates/b.md` (as in `templates/gates-node.md` N1) happens to be correct today only because index 0 is the flag, which the `--` test already drops.

## The fix

Exclude the value after `--timeout` only when the flag is present.

## Exercised by hand

- `gate-check.mjs gates/a.md` runs and rewrites `a.md` only; `b.md` untouched, box still open.
- `gate-check.mjs --timeout 5 gates/b.md` runs `b.md` only; the `5` is not treated as a file.
- `gate-check.mjs` with no arguments still scans `GATES.md` plus `gates/*.md`.
- `--status` with several files unchanged.

Zero dependencies, no format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)