### PR TITLE
fix: installer identifies its Stop hook by the install path, so a renamed skill dir breaks idempotence and --uninstall

### DIFF
--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -22,7 +22,9 @@ const global_ = args.includes("--global");
 const shared = args.includes("--shared");
 
 const hookScript = join(dirname(fileURLToPath(import.meta.url)), "stop-hook.mjs");
-const MARKER = "unlazy"; // identifies our entries: command mentions unlazy + stop-hook.mjs
+const MARKER = "unlazy"; // passed to the hook as an ignored argv tag, so identification
+                         // never depends on the skill living in a path named "unlazy"
+                         // (an argument, not a shell comment: cmd.exe has no "#")
 
 const target = global_
   ? join(homedir(), ".claude", "settings.json")
@@ -43,7 +45,9 @@ const stopHooks = Array.isArray(settings.hooks.Stop) ? settings.hooks.Stop : [];
 const isOurs = (entry) =>
   Array.isArray(entry?.hooks) &&
   entry.hooks.some(h => typeof h?.command === "string" &&
-    h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER));
+    h.command.includes("stop-hook.mjs") &&
+    // marker in the command, or, for entries written before it existed, our own path
+    (h.command.toLowerCase().includes(MARKER) || h.command.includes(hookScript)));
 
 const kept = stopHooks.filter(e => !isOurs(e));
 
@@ -63,7 +67,7 @@ if (uninstall) {
 const entry = {
   hooks: [{
     type: "command",
-    command: `node "${hookScript}"`,
+    command: `node "${hookScript}" --${MARKER}`,
     timeout: 20,
   }],
 };
@@ -78,7 +82,7 @@ mkdirSync(dirname(target), { recursive: true });
 writeFileSync(target, JSON.stringify(settings, null, 2) + "\n");
 
 console.log(`Installed unlazy Stop hook into ${target}
-  command: node "${hookScript}"
+  command: node "${hookScript}" --${MARKER}
   effect:  while GATES.md or gates/*.md in the working directory contain unmet
            gates, ending the turn is blocked (max 6 blocks without progress,
            ABANDON lines are honored as an honest exit).

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -49,6 +49,13 @@ const isOurs = (entry) =>
     // marker in the command, or, for entries written before it existed, our own path
     (h.command.toLowerCase().includes(MARKER) || h.command.includes(hookScript)));
 
+// Ours AND still pointing at this copy of the script. An entry left behind by
+// an install that has since moved is ours, but stale: it must be replaced, not
+// reported as already installed, or enforcement is silently off.
+const isCurrent = (entry) =>
+  Array.isArray(entry?.hooks) &&
+  entry.hooks.some(h => typeof h?.command === "string" && h.command.includes(hookScript));
+
 const kept = stopHooks.filter(e => !isOurs(e));
 
 if (uninstall) {
@@ -72,7 +79,7 @@ const entry = {
   }],
 };
 
-if (stopHooks.some(isOurs)) {
+if (stopHooks.some(isCurrent)) {
   console.log(`Already installed in ${target} (idempotent, nothing changed).`);
   process.exit(0);
 }

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -15,6 +15,9 @@
 // Progress = the combined content of the gate files changed since last block.
 // State lives in .unlazy-hook-state.json next to the gates (add to .gitignore).
 //
+// Argv is ignored. The installer appends "--unlazy" so its own entries stay
+// identifiable in settings without depending on the install path.
+//
 // Contract (docs: code.claude.com/docs/en/hooks):
 //   stdin  JSON with { cwd, stop_hook_active, ... }
 //   stdout {"decision":"block","reason":"..."} + exit 0 to block; exit 0 silent to allow.


### PR DESCRIPTION
## The bug

`scripts/install-hooks.mjs:46`

```js
h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER)
```

The command written into settings is `node "<hookScript>"`. Nothing in it says "unlazy" except the path, so `isOurs` is really asking "does this skill live in a directory named unlazy". Clone to `~/.claude/skills/unlazy` and it holds; anywhere else it silently stops holding.

When it does not hold:

- **install stops being idempotent**: `stopHooks.some(isOurs)` is false, so every run appends another Stop entry. Three runs, three identical hooks, each one blocking the same stop.
- **`--uninstall` becomes a no-op**: `kept.length === stopHooks.length`, so it prints `Nothing to remove` and leaves them in place. The documented escape hatch does not work, on the one feature that changes harness behavior.

## Reproduce

Copy the skill to a directory whose name is not `unlazy`, then from a project:

```
$ node ../fakeskill/scripts/install-hooks.mjs   # x3
$ node -e "console.log(JSON.parse(fs.readFileSync('.claude/settings.local.json')).hooks.Stop.length)"
3
$ node ../fakeskill/scripts/install-hooks.mjs --uninstall
Nothing to remove: no unlazy Stop hook found in .../settings.local.json
```

## The fix

Put the marker in the command, as an argument (`node "<hookScript>" --unlazy`), so identification never depends on the path. An argv tag rather than a `# unlazy` shell comment, because hook commands also run under `cmd.exe`, where `#` is not a comment; `stop-hook.mjs` ignores argv, and now says so in its header.

`isOurs` keeps a second signal, the script's own absolute path, so entries written by the current version can still be found and removed after upgrading.

## Exercised by hand

From a directory not named unlazy:

- install, install, install: **1** Stop entry, runs 2 and 3 print `Already installed`.
- `--uninstall`: removed, `settings.local.json` back to `{}`.
- two legacy entries (`node "<hookScript>"`, no marker) plus one unrelated `node /outra/skill/stop-hook.mjs`: `--uninstall` removes both legacy entries and **leaves the unrelated hook alone**.
- the hook itself, invoked with the extra argv, still blocks: `{"decision":"block","reason":"unlazy: 1 gate(s) unmet: G1. ..."}`, and still exits silently when no gate files are present.

Zero dependencies, POSIX and Windows safe, no gate format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)