### PR TITLE
Scope gate enforcement to one pipeline, and make its writes concurrency-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.unlazy/
+.unlazy-hook-state.json
+*.tmp
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## 2.1.0 (2026-08-22)
+
+Gate enforcement becomes safe to run in parallel: one scope per pipeline, file
+ownership as a checked lease, and gate files that survive being written while
+another run is in flight. Every item below is covered by a test in
+`tests/run-tests.mjs` (26 tests, run with `node tests/run-tests.mjs`).
+
+Fixed, in order of severity:
+
+- **`gate-check.mjs` silently dropped its first file argument** unless
+  `--timeout` happened to be passed. The arg filter excluded index `tIdx + 1`,
+  and `tIdx` is `-1` when `--timeout` is absent, so index `0` was always
+  removed. A call naming two leaves ran only the second and printed
+  `ALL MET (1 met)`; a call naming one leaf ran none of them, fell back to
+  discovery, and ran the whole tree. A false completion signal from the tool
+  whose job is preventing false completion signals. Replaced with a real
+  argument parser; unknown options now exit 2 instead of being read as files.
+- **Gate files were discovered by one glob over the working directory**, so any
+  run touched every gates file present. Concurrent leaves executed each other's
+  CHECK commands, wrote each other's `EVIDENCE:` lines and flipped each other's
+  boxes: a leaf could certify a sibling it had never read. Discovery is now
+  scoped to one pipeline and never crosses a scope boundary.
+- **The Stop hook blocked on gates the session did not own.** It scanned the
+  whole directory, so a finished pipeline was blocked by an unrelated one, named
+  the offending gate as a bare `G1` (unique only within a file), and shared one
+  `.unlazy-hook-state.json` progress counter across all pipelines, letting them
+  reset and exhaust each other's loop guard. The hook now resolves one scope,
+  keeps a counter per scope, reports file-qualified ids, and allows the stop
+  when it cannot tell whose pipeline it is looking at.
+- **Gate ids differed between the two scripts.** `gate-check` fell back to
+  `line<N>` for a gate with no `Gn:` prefix while `stop-hook` fell back to the
+  first 24 characters of the title, so such a gate had two identities and could
+  not be reliably abandoned. Both now share one parser.
+- **`install-hooks.mjs` identified its own entries by the literal word "unlazy"
+  in the hook script's path.** Vendoring or renaming the skill made it stack
+  duplicate Stop entries and report "nothing to remove" on uninstall. It now
+  matches the hook script's actual path, and still recognises entries written by
+  upstream v2.0.
+- **Gate files were written back from a whole-file snapshot** taken before the
+  checks ran, so a concurrent edit to a different gate in the same file was
+  erased. Writes now re-read under a lock, apply only the gates that run
+  resolved, and replace the file by atomic rename.
+
+New:
+
+- **Scopes.** A pipeline lives at `.unlazy/<scope>/` with its own gates, status
+  log, loop-guard counter and session binding. Selected by `--scope`,
+  `UNLAZY_SCOPE`, a session binding, or being the only pipeline present. When
+  several exist and none resolves, the tools refuse rather than guess.
+- **File-ownership leases.** `OWNS:` in a gates file plus `--claim` turns
+  `PLAN.md`'s "no two leaves own the same file" into a checked constraint;
+  overlap is refused with exit 3 and names the holder. `--release` frees them.
+- **`CWD:`** runs a single check somewhere other than the root, for a pipeline
+  whose checks belong in a subproject.
+- **`--log`** appends one line to the scope's status log, so `PLAN.md` is never
+  read-modify-written by concurrent leaves.
+- **`--bind`, `--list-scopes`, `--status`, `--root`, `--cwd`, `--help`**.
+- **`scripts/lib/gates.mjs`**: parsing, scope resolution, locking and leases in
+  one place, imported by both scripts.
+- **`tests/run-tests.mjs`**: 30 zero-dependency behavioural tests covering the
+  argument parser, scope isolation, refusal-on-ambiguity, concurrent-edit
+  survival, lease conflicts, per-scope hook counters and hook installation.
+- **`references/parallel.md`**: scopes, leases, and what is still the driver's
+  job.
+
+How many leaves run at once, and in what order, is deliberately left out: it
+belongs to the dispatcher, and rolling dispatch beats any batching this layer
+could impose.
+
+Unchanged: the method, the four passes, the report audit, the verification
+hierarchy, the token-economy rules, and the legacy layout: `GATES.md` plus
+`gates/*.md` in the working directory still works, so solo mode needs no
+migration.
+
 ## 2.0.0 (2026-08-10)
 
 Enforcement moved from prose into files, checks and an optional hook. Motivated by a controlled six-run test of v1 (two build tasks, three conditions each, independent code review plus adversarial verification plus live browser testing) whose headline results are in the README.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # unlazy
 
-**An anti-laziness skill for AI agents. v2: enforced, not requested.**
+**An anti-laziness skill for AI agents. v2.1: enforced, not requested, and safe to run in parallel.**
 
 v1 told the model to work harder. v2 makes half-done structurally visible:
 acceptance gates live in files, checks run as commands, and an optional hook
@@ -10,10 +10,14 @@ blocks the agent from declaring victory while gates are unmet.
 
 You do not promise you are done. You prove it against a ledger.
 
+v2.1 makes that ledger safe under concurrency. Each pipeline gets its own scope,
+file ownership is a checked lease rather than a promise in a plan, and gate files
+survive being written while another run is in flight.
+
 Works with Claude Code, OpenAI Codex, Cursor and anything else that reads `SKILL.md`.
 Hard enforcement (the Stop hook) is Claude Code only; everything else is plain markdown and Node.
 
-[Use it](#use-it) · [What changed in v2](#what-changed-in-v2-and-why) · [How it works](#how-it-works) · [The method](#the-depth-tree-v2) · [Costs](#what-it-costs) · [Research](#the-research)
+[Use it](#use-it) · [Parallel pipelines](#parallel-pipelines) · [What changed in v2](#what-changed-in-v2-and-why) · [How it works](#how-it-works) · [The method](#the-depth-tree-v2) · [Costs](#what-it-costs) · [Research](#the-research)
 
 </div>
 
@@ -67,7 +71,7 @@ node <path-to-skill>/scripts/install-hooks.mjs --global   # every project
 node <path-to-skill>/scripts/install-hooks.mjs --uninstall
 ```
 
-It is a millisecond file scan, zero tokens per check. If the agent makes no gate progress across six consecutive blocked stops, the hook releases it with a warning instead of trapping it, and an `ABANDON: <gate> <reason>` line is always honored as an honest exit. Add `.unlazy-hook-state.json` to your `.gitignore`.
+Add `--scope <id>` to pin the hook to one pipeline. It is a millisecond file scan, zero tokens per check. If the agent makes no gate progress across six consecutive blocked stops, the hook releases it with a warning instead of trapping it, and an `ABANDON: <gate> <reason>` line is always honored as an honest exit. A pipeline this session does not own never blocks it. Add `.unlazy/` to your `.gitignore`.
 
 ### Or let your agent install it
 
@@ -86,6 +90,54 @@ Then confirm it worked: show me the installed path and the first line of the
 skill's description. Do not tell me it is installed unless you have actually
 verified the file is on disk.
 ```
+
+## Parallel pipelines
+
+Running leaves at the same time is only safe if two things hold: no two of them write the same file, and the ledger survives being written from more than one place. v2.1 provides both, and leaves the scheduling to whatever dispatches the leaves.
+
+**Ownership is a lease, not a promise.** Each leaf declares what it may write:
+
+```markdown
+OWNS: src/api/**, tests/api/*.test.ts
+```
+
+```bash
+node scripts/gate-check.mjs --scope api --leaf leaf-1.2.1 --claim
+# CONFLICT src/shared/util.ts overlaps src/shared/** held by web/leaf-1
+# CLAIM REFUSED (1 conflict(s))          <- exit 3
+```
+
+The claim is checked against every other leaf in every pipeline, so "no two leaves touch the same file" is enforced rather than assumed by the dispatcher.
+
+**Across pipelines.** One scope per pipeline under `.unlazy/<scope>/`, selected by `--scope` or `UNLAZY_SCOPE`. Separate gates, separate status log, separate loop-guard counter, separate leases. Nothing in one scope can read, write or block another. When the scope is ambiguous the tools refuse rather than guess:
+
+```
+$ node scripts/gate-check.mjs
+gate-check: 2 pipelines present (api, web); pass --scope <id> or set UNLAZY_SCOPE.
+Refusing to run every pipeline's checks at once.
+```
+
+Prefer one `git worktree` per pipeline whenever the checks build anything: parallel builds in one tree just serialise on the toolchain's lock while looking busy.
+
+Full guide: [references/parallel.md](references/parallel.md).
+
+## What v2.1 changed
+
+Three defects in v2.0 made concurrent runs unsafe. Each is now covered by a test in `tests/run-tests.mjs`.
+
+| Defect in v2.0 | Effect | Fix |
+|---|---|---|
+| `gate-check` dropped its first file argument unless `--timeout` was passed (index arithmetic in the arg filter) | A scoped call fell back to "every gate file in the tree" and printed `ALL MET` for work it never looked at | A real argument parser; unknown options are an error |
+| Gate files were discovered by one glob over the working directory | A leaf running its own checks executed and rewrote every sibling's gates, so a leaf could certify a sibling it had never read | Scopes: discovery never crosses a pipeline boundary, and ambiguity is refused |
+| The Stop hook scanned the whole directory and kept one global loop-guard counter | A finished session was blocked by an unrelated pipeline's gates, reported as a bare `G1`, while pipelines reset each other's counter | Per-scope resolution, per-scope counter, file-qualified ids, and never blocking on a pipeline this session does not own |
+
+Also fixed: `install-hooks.mjs` identified its own entries by looking for the literal word "unlazy" in the hook's file path, so vendoring or renaming the skill made it stack duplicate hooks and fail to uninstall. It now matches the hook script's actual path, and still recognises entries written by upstream v2.0.
+
+Added: `OWNS:` with `--claim` and `--release`, `CWD:`, `--log`, `--bind`, `--list-scopes`, atomic delta writes under a file lock, and `tests/run-tests.mjs` (26 tests). Parsing and scope resolution moved into `scripts/lib/gates.mjs` so the checker and the hook cannot disagree about what a gate is.
+
+Deliberately not here: concurrent execution of a leaf's own checks, and leaf dispatch order. [#5](https://github.com/Leonxlnx/unlazy/pull/5) already implements both, with a sliding-window `--jobs` limiter and rolling dispatch, and rolling beats any fixed batching. This PR is the layer underneath: the guarantees that make running them at once safe.
+
+The legacy layout (`GATES.md` + `gates/*.md` in the working directory) still works unchanged, so solo mode needs no migration.
 
 ## What changed in v2, and why
 
@@ -162,18 +214,27 @@ references/
   method.md                    the Depth Tree v2 in full
   gates.md                     gate file format spec and writing guide
   orchestration.md             leaves as fresh agents, verification hierarchy
+  parallel.md                  scopes, leases, safe concurrent writes
   token-economy.md             cost discipline, measured
 templates/
   PLAN.md                      contract + tree + append-only status log
-  gates-leaf.md                per-leaf gates
+  gates-leaf.md                per-leaf gates, with OWNS
   gates-node.md                per-branch integration gates
 scripts/
   gate-check.mjs               runs CHECK commands, flips boxes, records evidence
   stop-hook.mjs                Claude Code Stop hook: blocks stop while gates unmet
   install-hooks.mjs            idempotent hook install/uninstall
+  lib/gates.mjs                shared parsing, scope resolution, locks, leases
+tests/
+  run-tests.mjs                26 behavioural tests; prints "N/N passed"
 ```
 
-All scripts are zero-dependency Node 16+, tested on Windows and POSIX shells.
+All scripts are zero-dependency Node 16+, tested on Windows and POSIX shells:
+
+```bash
+node tests/run-tests.mjs
+# 26/26 passed
+```
 
 ## The problem: model laziness is real and measured
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: unlazy
-description: Anti-laziness execution discipline for substantial tasks. Use when work keeps coming back half done, when an agent reports done before it is done, when output must be exhaustive rather than fast, on long autonomous runs that tend to stall at 80 percent, or on any invocation like /unlazy, "tree N", "gates", or "do not stop until it is done". v2 enforces completion through gate files and runnable checks instead of promises. Core method is the Depth Tree, which decomposes work into leaves that each get finished against their own gates.
+description: Anti-laziness execution discipline for substantial tasks. Use when work keeps coming back half done, when an agent reports done before it is done, when output must be exhaustive rather than fast, on long autonomous runs that tend to stall at 80 percent, or on any invocation like /unlazy, "tree N", "gates", or "do not stop until it is done". Also use when several pipelines or leaves must run in parallel without conflicting. v2 enforces completion through gate files and runnable checks instead of promises; v2.1 makes those gates safe to run concurrently, one scope per pipeline. Core method is the Depth Tree, which decomposes work into leaves that each get finished against their own gates.
 license: MIT
 metadata:
   author: Leonxlnx
   source: https://github.com/Leonxlnx/unlazy
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Unlazy
@@ -23,8 +23,10 @@ Why a file: your intentions do not survive a long context, files do. A checklist
 Done means every box is checked with evidence recorded. Run the bundled checker to execute the checks and record evidence for you:
 
 ```
-node <this-skill-dir>/scripts/gate-check.mjs GATES.md
+node <this-skill-dir>/scripts/gate-check.mjs
 ```
+
+It finds this pipeline's gates on its own. Name a file explicitly to work just that one (`gate-check.mjs gates/leaf-3.md`), and `--status` to report without running anything.
 
 Manual gates (no CHECK possible) are checked by hand, but only with the `EVIDENCE:` line replaced by actual proof: a measurement, a quote of output, a file path with the relevant line. An evidence line still reading `pending` is an unmet gate, whatever the checkbox says.
 
@@ -35,6 +37,8 @@ If a gate becomes genuinely impossible, do not quietly drop it. Add a line `ABAN
 **Solo** (default). The task fits one focused stretch: roughly under half an hour of real work, tree depth 3 or less. One `GATES.md`, work until it is fully checked, report with the ledger pasted.
 
 **Orchestrated**. The task is a build: tree depth 4 or more, or clearly beyond one sitting. Decompose per [references/method.md](references/method.md), write `PLAN.md` plus one gates file per leaf under `gates/`, and run each leaf as a fresh subagent with a narrow brief. Read [references/orchestration.md](references/orchestration.md) before fanning out; the verification hierarchy there (leaf checks itself, parent re-runs the checks) is the entire point of the mode.
+
+**Parallel**. Several leaves, or several whole pipelines, at once. Everything from orchestrated mode plus a scope per pipeline; read [references/parallel.md](references/parallel.md) first. Do not fan out concurrently without it: unscoped concurrent runs let one leaf tick another leaf's boxes.
 
 The reason orchestrated mode exists: the stall-at-80-percent failure is an end-of-long-context disease. A fresh context per leaf means every leaf starts with full attention. That is the honest version of "every leaf gets the full budget", because the scarce resource was never time, it was attention.
 
@@ -48,7 +52,16 @@ Created by Leonxlnx. In v2 the tree is a decomposition tool, not an effort multi
 4. **Branches get gates too.** Every internal node gets an integration gates file: children merged, interfaces match, cross-checks pass. Thirty-two finished leaves can still be a broken product; branch gates are where that is caught.
 5. **Effort per leaf comes from its gates**, not from N. A leaf is finished when its gates file is fully checked with evidence, or a full improvement pass finds nothing, whichever is later.
 
-Scale guidance: tree 2 or 3 for a feature, a bug hunt, a document, solo mode. Tree 4 or 5 for a subsystem or serious refactor. Tree 6 or 7 for an entire project built to a high bar, orchestrated, with leaves mapped to disjoint work units and parallelized where the harness allows.
+Scale guidance: tree 2 or 3 for a feature, a bug hunt, a document, solo mode. Tree 4 or 5 for a subsystem or serious refactor. Tree 6 or 7 for an entire project built to a high bar, orchestrated, with leaves mapped to disjoint work units and parallelized in waves.
+
+## Running things in parallel
+
+Sequential dispatch is the safe default, not the fast one. When wall clock matters, parallelise deliberately, on either axis:
+
+- **Across leaves.** Give each leaf `OWNS:`, the files it may write, in its gates file, and claim it with `--claim` before dispatching. An overlap with another leaf is refused, so "disjoint files" is checked instead of hoped for. That is the guarantee concurrent dispatch rests on.
+- **Across pipelines.** One scope per pipeline under `.unlazy/<scope>/`, selected with `--scope` or `UNLAZY_SCOPE`. Nothing in one scope can read, write or block another. Prefer one git worktree per pipeline when the checks build anything, or parallel builds just serialise on the toolchain's lock while looking busy.
+
+Parallelism buys wall clock and nothing else. It never reduces the verification you owe: the parent still re-runs every leaf's checks. Full detail in [references/parallel.md](references/parallel.md).
 
 ## Work each leaf in passes
 
@@ -63,7 +76,7 @@ A pass that produces no improvement, plus a fully checked gates file, is the onl
 
 The single most reproducible failure in tested runs: final reports whose numbers were wrong while their substance was right. Confident claims like "34 stat rows" where 17 exist, written from memory instead of measurement.
 
-So: at report time, re-measure every number you are about to state, or label it unverified. Paste the gates ledger with its count, N of N checked. A report is a set of claims backed by a ledger, never a vibe of completion.
+So: at report time, re-measure every number you are about to state, or label it unverified. Paste the gates ledger with its count, N of N checked. Refer to gates in the qualified form the tools print (`leaf-1.2.1:G3`), because a bare `G3` is ambiguous the moment a tree has more than one gates file. A report is a set of claims backed by a ledger, never a vibe of completion.
 
 ## Behavioral rules
 
@@ -83,18 +96,19 @@ Discipline is not maximalism, and enforcement should be nearly free. The rules t
 - Checks run as shell commands, not as you re-reading everything you wrote.
 - Evidence is capped: the deciding lines of output, never full logs.
 - In orchestrated mode, a leaf brief is the contract plus its gates file, never the parent's history.
-- Append to `PLAN.md`'s status log, do not rewrite the file.
+- Append to the status log with `--log`, do not rewrite `PLAN.md`.
 - Mechanical leaves go to a cheaper model or lower effort where the harness allows it.
 - Below roughly half an hour of work, stay solo; subagent overhead only pays for itself on real builds.
 
 ## Hard enforcement (Claude Code, optional)
 
-If the harness is Claude Code, this skill ships a Stop hook that structurally blocks ending the turn while `GATES.md` or `gates/*.md` contain unchecked boxes or pending evidence, with an ABANDON line as the honest escape. It converts "no report until done" from a rule into a wall.
+If the harness is Claude Code, this skill ships a Stop hook that structurally blocks ending the turn while this pipeline's gates contain unchecked boxes or pending evidence, with an ABANDON line as the honest escape. It converts "no report until done" from a rule into a wall. A pipeline this session does not own never blocks it.
 
 It changes harness behavior, so never install it silently. When a task would clearly benefit, offer it once:
 
 ```
-node <this-skill-dir>/scripts/install-hooks.mjs
+node <this-skill-dir>/scripts/install-hooks.mjs                  # this project
+node <this-skill-dir>/scripts/install-hooks.mjs --scope <id>     # pin to one pipeline
 ```
 
 and tell the user what it does and how to remove it (`--uninstall`). Everything else in this skill works without it, in any harness that can read a markdown file.

--- a/references/gates.md
+++ b/references/gates.md
@@ -1,13 +1,17 @@
 # Gate file format
 
 The machine-readable contract between "I say it is done" and "it is done".
-Both bundled scripts (`gate-check.mjs`, `stop-hook.mjs`) parse exactly this
-format, so any deviation weakens enforcement.
+`gate-check.mjs` and `stop-hook.mjs` both parse this format through one shared
+implementation (`scripts/lib/gates.mjs`), so the two can never disagree about
+what a gate is or what its id is. Any deviation from the format weakens
+enforcement.
 
 ## Format
 
 ```markdown
 # Gates: <scope name>
+
+OWNS: <globs this unit is allowed to write>
 
 Scope: <one line>
 
@@ -16,22 +20,43 @@ Scope: <one line>
   EXPECT: <substring or /regex/>
   EVIDENCE: pending
 
-- [ ] G2: <manual outcome>
+- [ ] G2: <outcome proven somewhere other than the root>
+  CHECK: npm run build
+  EXPECT: built in
+  CWD: packages/web
   EVIDENCE: pending
 
-ABANDON: G2 <reason, only if a gate had to be surrendered>
+- [ ] G3: <manual outcome>
+  EVIDENCE: pending
+
+ABANDON: G3 <reason, only if a gate had to be surrendered>
 ```
 
 ## Parsing rules
 
 - A gate starts at a line matching `- [ ]` or `- [x]` (case-insensitive x).
-- Indented `CHECK:`, `EXPECT:`, `EVIDENCE:` lines up to the next gate belong
-  to the gate above them.
+- Indented `CHECK:`, `EXPECT:`, `EVIDENCE:`, `CWD:` lines up to the next gate
+  belong to the gate above them.
+- `OWNS:` is a file-level header, read only before the first gate, and takes a
+  comma-separated list of globs.
 - `EXPECT:` is a plain substring match against the command's combined
   stdout+stderr, unless wrapped in slashes, then it is a JavaScript regex
   (e.g. `/8\/8 passed/`).
-- `ABANDON: G<n> <reason>` anywhere in the file marks that gate as
-  honestly surrendered. Tools treat it as resolved but reports must list it.
+- `CWD:` runs that one check in that directory, resolved against `--cwd` (or the
+  root when `--cwd` is absent).
+- `ABANDON: G<n> <reason>` anywhere in the file marks that gate as honestly
+  surrendered. Tools treat it as resolved but reports must list it.
+
+## Gate ids
+
+A gate's id is the token before the first colon in its title (`G1`, `N3`), or
+`L<line number>` when there is none. Always write an explicit id: it is what
+`ABANDON` refers to.
+
+Ids are unique **within a file**, not across a tree, so both tools report them
+qualified by file stem: `leaf-1.2.1:G3`, `node-1.1:N2`. Use the qualified form
+in reports and when telling a leaf which gate to go finish. Inside a gates file,
+`ABANDON: G3` still means that file's G3.
 
 ## What counts as UNMET
 
@@ -52,6 +77,10 @@ A gate is unmet if any of these hold:
   ask whether the outcome is observable at all; if it is not, sharpen it.
 - **Make EXPECT decisive.** Match the line that can only appear on success
   (`8/8 passed`), not one that appears either way (`done`).
+- **Assert the positive string, never the absence of an error.** A CHECK that
+  pipes (`npm test | tail`) reports the *last* command's status, so a killed
+  build reads as success. Either set `-o pipefail`, or let `EXPECT` require the
+  line that can only appear on success.
 - **Cap evidence.** gate-check records the deciding tail of output. When
   filling manual evidence by hand, quote the deciding lines or cite
   `file:line`, never paste a log.
@@ -64,3 +93,9 @@ Any number that will appear in a final report deserves its own gate with a
 CHECK that measures it. Measured runs of v1 showed reports whose only false
 claims were numbers stated from memory. If a number matters enough to
 report, it matters enough to measure at report time.
+
+## Concurrency
+
+`OWNS:` is what makes a leaf's file ownership checkable instead of a promise in
+`PLAN.md`. It is not required for solo mode. Full detail in
+[parallel.md](parallel.md).

--- a/references/orchestration.md
+++ b/references/orchestration.md
@@ -9,45 +9,72 @@ not time, is the scarce resource, and a fresh subagent per leaf resets it.
 You (the main session) are the driver. You do not implement leaves; you
 plan, dispatch, verify, and integrate.
 
-1. **Plan.** Write PLAN.md (contract, tree, gates file per leaf and branch)
-   from templates/PLAN.md. This is the only step where the whole task must
-   fit in one head.
-2. **Dispatch one leaf.** Spawn a subagent whose entire brief is:
+1. **Plan.** Pick a scope id for this pipeline and write
+   `.unlazy/<scope>/PLAN.md` from `templates/PLAN.md`: contract, tree, one gates
+   file per leaf and branch, each leaf declaring the files it `OWNS:`. This is
+   the only step where the whole task must fit in one head.
+2. **Claim ownership before dispatching.**
+   ```
+   node gate-check.mjs --scope <id> --leaf <leaf> --claim   # per leaf
+   ```
+   A refused claim means two leaves want the same file: fix the split before
+   dispatching anything. Everything downstream of here assumes disjoint
+   ownership, so this is the step that makes the assumption true.
+3. **Dispatch the leaves that are ready.** One subagent per leaf, each with a
+   brief that is only:
    - the contract section of PLAN.md (not the whole file, not your history)
    - its own gates file, verbatim
+   - `UNLAZY_SCOPE=<id>` and the exact `gate-check` invocation to use
    - the instruction: work the four passes until every gate is met with
      evidence, then stop; if a gate is impossible, ABANDON it with a reason.
-3. **Verify, never trust.** When the leaf returns, re-run its checks
-   yourself: `node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-x.md`
-   and rerun a spot-check of the CHECK commands. A leaf that checked its own
-   boxes without evidence gets sent back with the specific unmet gates named.
-   This is the layer that makes self-certification worthless.
-4. **Log and advance.** Append one line to PLAN.md's status log. Dispatch the
-   next leaf. When all children of a branch are verified, work the branch's
-   integration gates yourself (or dispatch an integration leaf for it).
-5. **Report.** Only when the root's gates are met. Paste the ledger, N of N,
-   with every ABANDON line surfaced, and re-measure every number you state.
+
+   Leaves dispatched together own disjoint files by construction, so they
+   cannot conflict. Where the harness offers per-agent worktree isolation, use
+   it: it also stops parallel builds from contending over one target directory.
+4. **Verify, never trust.** As each leaf returns, re-run *its* checks yourself:
+   ```
+   node gate-check.mjs --scope <id> .unlazy/<id>/gates/leaf-x.md --status
+   ```
+   and spot-check a CHECK command by hand. A leaf that checked its own boxes
+   without evidence gets sent back with the specific unmet gates named, in
+   qualified form (`leaf-1.2.1:G3`). This is the layer that makes
+   self-certification worthless. Verification is per leaf, so it starts the
+   moment a leaf returns. Do not wait for the others.
+5. **Log and advance.**
+   ```
+   node gate-check.mjs --scope <id> --log "leaf-1.2.1 verified, 7/7"
+   ```
+   Dispatch whatever the returned leaf unblocks. When all children of a branch
+   are verified, work the branch's integration gates yourself (or dispatch an
+   integration leaf).
+6. **Report.** Only when the root's gates are met. Release the leases
+   (`--release`), paste the ledger, N of N, with every ABANDON line surfaced,
+   and re-measure every number you state.
 
 ## Parallelism
 
-Leaves whose file ownership is disjoint (the contract guarantees this) can
-run concurrently if the harness supports parallel subagents. Parallelism
-buys wall-clock time, not token savings; do not use it as an excuse to skip
-per-leaf verification. If two leaves ever need the same file, fix the plan,
-do not coordinate through hope.
+Leaves whose `OWNS:` globs are disjoint can be dispatched at the same time, and
+the lease check is what turns that from an assumption into a fact. This file
+does not decide how many run at once: that is the dispatcher's business.
+
+Parallelism buys wall-clock time, not token savings, and never excuses skipping
+per-leaf verification. Running several pipelines at once, as opposed to several
+leaves of one pipeline, is a scope-per-pipeline question; see
+[parallel.md](parallel.md).
 
 ## Verification hierarchy
 
 Three layers, weakest to strongest, each catching what the layer below
 misses:
 
-1. **Leaf self-check**: gate-check run by the leaf itself. Catches honest
-   incompleteness, misses self-deception.
+1. **Leaf self-check**: gate-check run by the leaf itself, scoped to its own
+   gates file. Catches honest incompleteness, misses self-deception.
 2. **Parent re-run**: the driver re-executes the checks. Catches
    self-deception and environment differences.
 3. **Stop-hook** (Claude Code, optional): structurally blocks a session from
-   ending while gates are unmet. Catches the driver itself drifting into
-   report mode.
+   ending while *this pipeline's* gates are unmet. Catches the driver itself
+   drifting into report mode. Install it with `--scope <id>` so it guards the
+   pipeline this session owns and no other.
 
 Prose discipline is layer zero and it is the weakest; that is the lesson v2
 is built on. Prefer moving any repeated judgment call up this hierarchy:
@@ -67,5 +94,5 @@ weak driver invalidates every verification above layer one.
 
 Below roughly half an hour of real work, subagent overhead (context
 re-establishment per leaf) costs more than it buys. Stay solo: one GATES.md,
-one session, same discipline. The gates still do their job; you just skip
-the dispatch machinery.
+one session, same discipline, no `.unlazy/` directory needed. The gates still do
+their job; you just skip the dispatch machinery.

--- a/references/parallel.md
+++ b/references/parallel.md
@@ -1,0 +1,136 @@
+# Parallel pipelines
+
+v2.0 could only run one pipeline at a time, and its tooling assumed so
+implicitly rather than saying so. Every gate file in the working directory was
+discovered by one glob, so any `gate-check` run touched every leaf in the tree:
+concurrent leaves executed each other's CHECK commands, wrote each other's
+evidence, and flipped each other's boxes. A leaf could certify a sibling it had
+never looked at. The Stop hook had the mirror problem, blocking a finished
+session because an unrelated pipeline's gates were unmet, and naming the
+offending gate `G1`, an id that is only unique inside one file.
+
+v2.1 gives every pipeline a **scope**. A scope is the unit of isolation: its own
+gates, its own status log, its own loop-guard counter, its own file ownership
+leases. Nothing in one scope can read, write or block another.
+
+## Layout
+
+```
+.unlazy/
+  <scope>/
+    PLAN.md            contract + tree for this pipeline
+    GATES.md           root and branch gates
+    gates/leaf-*.md    one file per leaf
+    status.log         append-only, this pipeline's events
+    session            optional: the Claude Code session id that owns this scope
+    hook-state.json    this pipeline's loop-guard counter
+  locks/
+    *.lease            file-ownership claims, across all scopes
+    *.filelock         short-lived write locks
+```
+
+Add `.unlazy/` to `.gitignore`. The legacy layout (`GATES.md` and `gates/*.md`
+directly in the working directory) still works unchanged for solo mode; you only
+need `.unlazy/` once a second pipeline exists.
+
+## Choosing the scope
+
+Every tool call resolves exactly one scope, in this order:
+
+1. `--scope <id>` on the command line.
+2. `UNLAZY_SCOPE` in the environment. Set this once per dispatched pipeline and
+   every call inside it is scoped without further thought.
+3. The session binding: the id in `.unlazy/<scope>/session`, matched against the
+   `session_id` a Stop hook receives. Write it with
+   `gate-check.mjs --scope <id> --bind <session-id>`.
+4. The only pipeline present, when there is exactly one.
+5. The legacy layout, when `.unlazy/` does not exist.
+
+**When several pipelines exist and none of the above resolves one, the tools
+refuse rather than guess.** `gate-check` exits 2 with the list of candidates;
+the Stop hook allows the stop and says why. Both are deliberate: silently
+running every pipeline's checks is the bug this design exists to remove, and
+blocking a session over gates it does not own is unactionable noise.
+
+## Two ways to run pipelines side by side
+
+**Separate worktrees, one pipeline each.** The default choice, and the only one
+that also solves build contention. One `git worktree` per pipeline, each with
+its own `.unlazy/<scope>/`, each with the Stop hook installed as
+`--scope <id>`. Independent working copies mean parallel `npm run build` or
+`cargo check` do not fight over one target directory, which on an I/O-bound
+tree is the difference between real parallelism and two builds serialising on a
+lock while both look busy.
+
+**One working copy, several scopes.** Cheaper to set up, and correct as long as
+leaves own disjoint files. Use it when the pipelines are mostly independent
+reads or touch clearly separate directories. Claim ownership explicitly (below)
+so "disjoint" is checked rather than assumed.
+
+## File ownership as a lease, not a promise
+
+`PLAN.md` has always said no two leaves may own the same file. Declare it in the
+leaf's gates file and the claim becomes checkable:
+
+```markdown
+OWNS: src/api/**, tests/api/*.test.ts
+```
+
+```
+node gate-check.mjs --scope api --leaf leaf-1.2.1 --claim
+```
+
+A claim that overlaps a lease held by any other leaf, in any scope, is refused
+with exit 3 and names the holder:
+
+```
+CONFLICT src/shared/util.ts overlaps src/shared/** held by web/leaf-1
+CLAIM REFUSED (1 conflict(s))
+```
+
+Overlap is decided on each glob's literal prefix, so `src/a/**` and `src/b/**`
+are disjoint while `src/shared/**` and `src/shared/util.ts` are not. The test is
+deliberately conservative: it can report a conflict a full glob intersection
+would clear, never the reverse. A refused claim means the plan is wrong: fix
+the split. Do not coordinate through hope.
+
+Release at the end of a pipeline with `--release` (whole scope) or
+`--release --leaf <name>` (one leaf).
+
+## How many run at once is not this file's business
+
+Ownership leases say which leaves *may* run together. They do not say how many
+do, or in what order, and nothing here tries to: a dispatcher that launches
+every ready leaf and starts whatever a returning leaf unblocks is strictly
+better than any fixed batching this file could impose, and concurrent execution
+of one leaf's own checks is a separate concern again. What the leases give that
+layer is the guarantee it needs, which is that two leaves running at the same
+time cannot be writing the same file.
+
+## Writes are safe under concurrency
+
+`gate-check` no longer writes back a whole-file snapshot taken before the checks
+ran. It re-reads the file under a lock, applies only the gates *that run*
+resolved, and replaces the file by atomic rename. A gate hand-edited by someone
+else while checks were in flight survives; a reader never sees a half-written
+file. Locks are created with `open(..., "wx")`, which is atomic on NTFS and
+POSIX alike, and any lock older than five minutes is broken so a killed process
+cannot wedge a pipeline.
+
+The status log is appended with `appendFileSync`, never rewritten, so
+concurrent leaves cannot lose each other's lines:
+
+```
+node gate-check.mjs --scope api --log "leaf-1.2.1 verified, 7/7 gates"
+```
+
+## What is still your job
+
+- **Gate ids are unique per file, not per tree.** Tools report them qualified
+  (`leaf-1.2.1:G3`), and that is the form to use in a report. Inside a file,
+  `ABANDON: G3` still refers to that file's G3.
+- **Ownership overlap is only checked for what you declare.** A leaf with no
+  `OWNS:` header claims nothing and is trusted with everything.
+- **Verification does not become optional because leaves ran concurrently.**
+  Parallelism buys wall clock, nothing else. The parent still re-runs every
+  leaf's checks; three layers of the hierarchy, unchanged.

--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -20,7 +20,9 @@ const statusOnly = args.includes("--status");
 let timeoutSec = 120;
 const tIdx = args.indexOf("--timeout");
 if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+// indexOf returns -1 when --timeout is absent, so guard the skip: without this,
+// `i !== tIdx + 1` excludes argv index 0 and swallows the first file argument.
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && (tIdx === -1 || i !== tIdx + 1));
 
 function defaultFiles(dir) {
   const found = [];

--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -1,167 +1,293 @@
 #!/usr/bin/env node
-// gate-check.mjs : run the CHECK commands in gate files, flip boxes, record evidence.
-// Zero dependencies. Node 16+. Part of the unlazy skill (v2).
+// gate-check.mjs : run the CHECK commands in gate files, flip boxes, record
+// evidence. Part of the unlazy skill (v2.1, multi-pipeline).
+//
+// Zero dependencies. Node 18+.
 //
 // Usage:
-//   node gate-check.mjs [file ...]          run unmet gates' checks, update files
-//   node gate-check.mjs --status [file ...] report only, change nothing
-//   node gate-check.mjs --timeout 60 ...    per-check timeout in seconds (default 120)
+//   gate-check.mjs [options] [file ...]
 //
-// Files default to GATES.md plus gates/*.md in the current directory.
-// Exit codes: 0 = all gates met (or honestly abandoned), 1 = unmet gates remain,
-//             2 = usage or parse error.
+// Actions (default: run the unmet gates' checks and update the files):
+//   --status              report only, change nothing
+//   --claim               take ownership leases from OWNS: headers
+//   --release             drop this scope's (or this leaf's) leases
+//   --log "<line>"        append one line to the scope status log
+//   --bind <session-id>   bind a Claude Code session to this scope, so the
+//                         Stop hook guards this pipeline and no other
+//   --list-scopes         list the pipelines present under .unlazy/
+//
+// Targeting:
+//   --scope <id>          the pipeline under .unlazy/<id>/ (or UNLAZY_SCOPE)
+//   --leaf <name>         which gate file the --claim/--release applies to
+//   [file ...]            explicit gate files; overrides scope discovery
+//
+// Options:
+//   --timeout S           per-check timeout in seconds (default 120)
+//   --cwd DIR             default working directory for CHECK commands
+//   --root DIR            where .unlazy/ lives (default process cwd)
+//
+// With no explicit files and no scope, a single pipeline is used automatically;
+// several pipelines is an error rather than a guess, because running every
+// pipeline's checks at once is how leaves end up certifying each other.
+//
+// Exit codes: 0 = all gates met (or honestly abandoned), 1 = unmet gates
+//             remain, 2 = usage or parse error, 3 = lease conflict.
 
-import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { readFileSync, existsSync, mkdirSync } from "node:fs";
+import { exec } from "node:child_process";
+import { basename, resolve, join, dirname } from "node:path";
+import {
+  parseGates, qualify, gateState, expectMatches, tail,
+  resolveTarget, listScopes, appendStatus, withFileLock, writeAtomic,
+  claimLeases, releaseLeases, scopeRoot, UNLAZY_DIR,
+} from "./lib/gates.mjs";
 
-const args = process.argv.slice(2);
-const statusOnly = args.includes("--status");
-let timeoutSec = 120;
-const tIdx = args.indexOf("--timeout");
-if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-// indexOf returns -1 when --timeout is absent, so guard the skip: without this,
-// `i !== tIdx + 1` excludes argv index 0 and swallows the first file argument.
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && (tIdx === -1 || i !== tIdx + 1));
+// ------------------------------------------------------------------- args
 
-function defaultFiles(dir) {
-  const found = [];
-  const top = join(dir, "GATES.md");
-  if (existsSync(top)) found.push(top);
-  const gdir = join(dir, "gates");
-  if (existsSync(gdir)) {
-    for (const f of readdirSync(gdir)) {
-      if (f.endsWith(".md")) found.push(join(gdir, f));
+// A real parser. The previous index-arithmetic filter silently dropped the
+// first file argument whenever --timeout was absent, which made a scoped call
+// fall back to "every gate file in the tree" and report ALL MET for work it
+// had never looked at.
+const FLAGS = new Set(["--status", "--claim", "--release", "--list-scopes", "--help", "-h"]);
+const VALUED = new Set(["--scope", "--leaf", "--timeout", "--cwd", "--root", "--log", "--bind"]);
+
+function parseArgs(argv) {
+  const opt = {};
+  const files = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (FLAGS.has(a)) { opt[a.replace(/^-+/, "")] = true; continue; }
+    if (VALUED.has(a)) {
+      const v = argv[++i];
+      if (v === undefined) return { error: a + " needs a value" };
+      opt[a.replace(/^-+/, "")] = v;
+      continue;
     }
+    if (a.startsWith("--")) {
+      const eq = a.indexOf("=");
+      if (eq !== -1) {
+        const k = a.slice(0, eq), v = a.slice(eq + 1);
+        if (VALUED.has(k)) { opt[k.replace(/^-+/, "")] = v; continue; }
+      }
+      return { error: "unknown option " + a };
+    }
+    files.push(a);
   }
-  return found;
+  return { opt, files };
 }
 
-const files = fileArgs.length ? fileArgs : defaultFiles(process.cwd());
-if (!files.length) {
-  console.error("gate-check: no gate files found (GATES.md or gates/*.md)");
+const parsed = parseArgs(process.argv.slice(2));
+if (parsed.error) {
+  console.error("gate-check: " + parsed.error);
   process.exit(2);
 }
+const { opt, files: fileArgs } = parsed;
 
-const GATE_RE = /^- \[( |x|X)\] (.*)$/;
-const ATTR_RE = /^\s+(CHECK|EXPECT|EVIDENCE):\s?(.*)$/;
-const ABANDON_RE = /^ABANDON:\s*(\S+)\s*(.*)$/;
-
-function parse(lines) {
-  const gates = [];
-  const abandoned = new Map(); // id -> reason
-  let cur = null;
-  lines.forEach((line, i) => {
-    const g = line.match(GATE_RE);
-    if (g) {
-      const id = (g[2].match(/^(\S+?):/) || [null, `line${i + 1}`])[1];
-      cur = {
-        line: i, checked: g[1].toLowerCase() === "x",
-        title: g[2].trim().replace(/^\S+?:\s*/, ""),
-        id,
-        check: null, expect: null, evidence: null, evidenceLine: -1,
-      };
-      gates.push(cur);
-      return;
-    }
-    const a = cur && line.match(ATTR_RE);
-    if (a) {
-      const key = a[1].toLowerCase();
-      cur[key] = a[2].trim();
-      if (key === "evidence") cur.evidenceLine = i;
-      return;
-    }
-    const ab = line.match(ABANDON_RE);
-    if (ab) abandoned.set(ab[1].replace(/:$/, ""), ab[2] || "(no reason)");
-    if (/^#|^- /.test(line) && !g) cur = null;
-  });
-  return { gates, abandoned };
+if (opt.help || opt.h) {
+  console.log(readFileSync(new URL(import.meta.url)).toString()
+    .split(/\r?\n/).filter(l => l.startsWith("//")).map(l => l.replace(/^\/\/ ?/, "")).join("\n"));
+  process.exit(0);
 }
 
-function expectMatches(expect, output) {
-  const rx = expect.match(/^\/(.+)\/([a-z]*)$/);
-  if (rx) {
-    try { return new RegExp(rx[1], rx[2]).test(output); } catch { return false; }
-  }
-  return output.includes(expect);
+const root = resolve(opt.root || process.cwd());
+const timeoutSec = Number(opt.timeout) > 0 ? Number(opt.timeout) : 120;
+const defaultCwd = opt.cwd ? resolve(root, opt.cwd) : root;
+
+if (opt["list-scopes"]) {
+  const s = listScopes(root);
+  console.log(s.length ? s.join("\n") : "(no pipelines under " + UNLAZY_DIR + "/)");
+  process.exit(0);
 }
 
-function tail(output, max = 200) {
-  const lines = output.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
-  const last = lines.slice(-2).join(" | ");
-  return (last || "(no output)").slice(0, max);
+// ----------------------------------------------------------------- target
+
+const target = resolveTarget({ root, scope: opt.scope, files: fileArgs });
+if (target.error) {
+  console.error("gate-check: " + target.error);
+  process.exit(2);
 }
-
-let totalUnmet = 0;
-let totalMet = 0;
-let totalAbandoned = 0;
-
-for (const file of files) {
-  let text;
-  try { text = readFileSync(file, "utf8"); } catch (e) {
-    console.error(`gate-check: cannot read ${file}: ${e.message}`);
+if (!target.files.length) {
+  console.error("gate-check: no gate files found (looked for " + UNLAZY_DIR +
+    "/<scope>/, then GATES.md and gates/*.md under " + root + ")");
+  process.exit(2);
+}
+for (const f of target.files) {
+  if (!existsSync(f)) {
+    console.error("gate-check: no such gate file: " + f);
     process.exit(2);
   }
-  const lines = text.split(/\r?\n/);
-  const { gates, abandoned } = parse(lines);
-  if (!gates.length) {
-    console.log(`${file}: no gates found`);
+}
+const scope = target.scope;
+
+function load(file) {
+  return Object.assign({ file }, parseGates(readFileSync(file, "utf8")));
+}
+
+// ---------------------------------------------------------------- --log
+
+if (opt.log) {
+  const p = appendStatus(root, scope, opt.log);
+  console.log("appended to " + p);
+  process.exit(0);
+}
+
+if (opt.bind) {
+  if (!scope) {
+    console.error("gate-check: --bind needs a scope (--scope <id>)");
+    process.exit(2);
+  }
+  const p = join(scopeRoot(root, scope), "session");
+  mkdirSync(dirname(p), { recursive: true });
+  writeAtomic(p, String(opt.bind).trim() + "\n");
+  console.log("bound session " + opt.bind + " to scope " + scope);
+  process.exit(0);
+}
+
+// --------------------------------------------------- --claim / --release
+
+if (opt.claim || opt.release) {
+  if (!scope) {
+    console.error("gate-check: --claim/--release need a scope (--scope <id> or a single pipeline under " + UNLAZY_DIR + "/)");
+    process.exit(2);
+  }
+  // --release with no --leaf drops the whole pipeline's leases, which is what a
+  // driver wants at the end of a run; --claim always needs one specific leaf.
+  if (opt.release) {
+    const n = releaseLeases(root, { scope, leaf: opt.leaf || null });
+    console.log("released " + n + " lease(s) for " + scope + (opt.leaf ? "/" + opt.leaf : ""));
+    process.exit(0);
+  }
+  const leafArg = opt.leaf || (target.files.length === 1
+    ? basename(target.files[0]).replace(/\.md$/i, "")
+    : null);
+  if (!leafArg) {
+    console.error("gate-check: --claim needs --leaf <name> when the scope holds several gate files");
+    process.exit(2);
+  }
+  const gf = target.files.find(f => basename(f).replace(/\.md$/i, "") === leafArg) || target.files[0];
+  const globs = load(gf).owns;
+  if (!globs.length) {
+    console.error("gate-check: " + basename(gf) + " declares no OWNS: paths, so there is nothing to claim");
+    process.exit(2);
+  }
+  const res = claimLeases(root, { scope, leaf: leafArg, globs });
+  if (!res.ok) {
+    for (const c of res.conflicts) {
+      console.log("CONFLICT " + c.glob + " overlaps " + c.theirGlob + " held by " + c.with);
+    }
+    if (res.error) console.error("gate-check: " + res.error);
+    console.log("CLAIM REFUSED (" + res.conflicts.length + " conflict(s))");
+    process.exit(3);
+  }
+  console.log("CLAIMED " + globs.length + " path(s) for " + scope + "/" + leafArg + ": " + globs.join(", "));
+  process.exit(0);
+}
+
+// ------------------------------------------------------------ check runner
+
+function runCheck(gate) {
+  return new Promise((res) => {
+    const cwd = gate.cwd ? resolve(defaultCwd, gate.cwd) : defaultCwd;
+    exec(gate.check, {
+      cwd, timeout: timeoutSec * 1000, maxBuffer: 8 * 1024 * 1024,
+      windowsHide: true, encoding: "utf8",
+    }, (err, stdout, stderr) => {
+      const output = (stdout || "") + "\n" + (stderr || "");
+      // With an EXPECT, the match decides (a check may exit non-zero by
+      // design); without one, the exit code decides.
+      const ok = gate.expect
+        ? expectMatches(gate.expect, output)
+        : !err;
+      res({ ok, output, error: err && err.killed ? "timed out after " + timeoutSec + "s" : (err ? err.message : null) });
+    });
+  });
+}
+
+// --------------------------------------------------------------- main run
+
+let totalMet = 0, totalUnmet = 0, totalAbandoned = 0;
+const unmetIds = [];
+
+for (const file of target.files) {
+  const doc = load(file);
+  if (!doc.gates.length) {
+    console.log(basename(file) + ": no gates found");
     continue;
   }
-  let changed = false;
 
-  for (const gate of gates) {
-    const isAbandoned = abandoned.has(gate.id);
-    const pendingEvidence = !gate.evidence || /^pending$/i.test(gate.evidence);
+  const runnable = opt.status ? [] : doc.gates.filter(g => {
+    if (doc.abandoned.has(g.id)) return false;
+    if (!g.check) return false;
+    const st = gateState(g, doc.abandoned);
+    return st === "unmet" || st === "unmet-no-evidence";
+  });
 
-    if (isAbandoned) { totalAbandoned++; continue; }
+  const results = [];
+  for (const gate of runnable) results.push(await runCheck(gate));
 
-    // Run checks for gates that are unchecked, or checked but missing evidence.
-    const needsRun = !statusOnly && gate.check && (!gate.checked || pendingEvidence);
-    if (needsRun) {
-      const res = spawnSync(gate.check, {
-        shell: true, encoding: "utf8", timeout: timeoutSec * 1000,
-        maxBuffer: 8 * 1024 * 1024,
-      });
-      const output = `${res.stdout || ""}\n${res.stderr || ""}`;
-      // With an EXPECT, the match decides (a check may exit non-zero by design);
-      // without one, the exit code decides.
-      const ok = gate.expect ? expectMatches(gate.expect, output) : res.status === 0;
-      if (ok) {
-        lines[gate.line] = lines[gate.line].replace(/^- \[ \]/, "- [x]");
-        if (gate.evidenceLine !== -1) {
-          const indent = lines[gate.evidenceLine].match(/^\s*/)[0];
-          lines[gate.evidenceLine] = `${indent}EVIDENCE: ${tail(output)}`;
+  // Print in gate order regardless of completion order, so two runs of the
+  // same file produce the same transcript.
+  const resolved = new Map();
+  runnable.forEach((g, idx) => {
+    const r = results[idx];
+    if (r && r.ok) {
+      resolved.set(g.id, tail(r.output));
+      console.log("  PASS " + qualify(file, g.id) + ": " + g.title);
+    } else {
+      const why = r ? (r.error || tail(r.output)) : "(not run)";
+      console.log("  FAIL " + qualify(file, g.id) + ": " + g.title + "\n       " + why);
+    }
+  });
+
+  if (resolved.size) {
+    // Re-read under a lock and apply only the gates this run resolved, so a
+    // concurrent edit to a different gate in the same file is not clobbered
+    // by a stale whole-file snapshot.
+    await withFileLock(root, file, () => {
+      const fresh = parseGates(readFileSync(file, "utf8"));
+      const lines = fresh.lines;
+      let changed = false;
+      for (const g of fresh.gates) {
+        if (!resolved.has(g.id)) continue;
+        const ev = resolved.get(g.id);
+        if (/^- \[ \]/.test(lines[g.line])) {
+          lines[g.line] = lines[g.line].replace(/^- \[ \]/, "- [x]");
+          changed = true;
         }
-        gate.checked = true;
-        gate.evidence = tail(output);
-        changed = true;
-        console.log(`  PASS ${gate.id}: ${gate.title}`);
-      } else {
-        const why = res.error ? res.error.message : tail(output);
-        console.log(`  FAIL ${gate.id}: ${gate.title}\n       ${why}`);
+        if (g.evidenceLine !== -1) {
+          const indent = lines[g.evidenceLine].match(/^\s*/)[0];
+          const next = indent + "EVIDENCE: " + ev;
+          if (lines[g.evidenceLine] !== next) { lines[g.evidenceLine] = next; changed = true; }
+        }
       }
-    }
-
-    const evidenceNow = gate.evidence && !/^pending$/i.test(gate.evidence);
-    if (gate.checked && evidenceNow) totalMet++;
-    else {
-      totalUnmet++;
-      if (statusOnly) {
-        const why = !gate.checked ? "unchecked" : "checked but EVIDENCE pending";
-        console.log(`  UNMET ${gate.id} (${why}): ${gate.title}`);
-      }
-    }
+      if (changed) writeAtomic(file, lines.join("\n"));
+    });
   }
 
-  if (changed) writeFileSync(file, lines.join("\n"));
-  console.log(`${file}: ${gates.length} gates`);
+  // Tally from what is on disk now, never from what we believe we just did.
+  const after = parseGates(readFileSync(file, "utf8"));
+  for (const g of after.gates) {
+    const st = gateState(g, after.abandoned);
+    if (st === "abandoned") { totalAbandoned++; continue; }
+    if (st === "met") { totalMet++; continue; }
+    totalUnmet++;
+    unmetIds.push(qualify(file, g.id));
+    if (opt.status) {
+      const why = st === "unmet" ? "unchecked" : "checked but EVIDENCE pending";
+      console.log("  UNMET " + qualify(file, g.id) + " (" + why + "): " + g.title);
+    }
+  }
+  console.log(basename(file) + ": " + after.gates.length + " gates");
 }
 
+const where = scope ? " [scope " + scope + "]" : "";
 if (totalUnmet === 0) {
-  console.log(`ALL MET (${totalMet} met${totalAbandoned ? `, ${totalAbandoned} abandoned` : ""})`);
+  console.log("ALL MET (" + totalMet + " met" +
+    (totalAbandoned ? ", " + totalAbandoned + " abandoned" : "") + ")" + where);
   process.exit(0);
-} else {
-  console.log(`UNMET: ${totalUnmet} (met: ${totalMet}${totalAbandoned ? `, abandoned: ${totalAbandoned}` : ""})`);
-  process.exit(1);
 }
+console.log("UNMET: " + totalUnmet + " (met: " + totalMet +
+  (totalAbandoned ? ", abandoned: " + totalAbandoned : "") + ")" + where);
+console.log("  " + unmetIds.slice(0, 12).join(", ") +
+  (unmetIds.length > 12 ? ", +" + (unmetIds.length - 12) + " more" : ""));
+process.exit(1);

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -22,7 +22,9 @@ const global_ = args.includes("--global");
 const shared = args.includes("--shared");
 
 const hookScript = join(dirname(fileURLToPath(import.meta.url)), "stop-hook.mjs");
-const MARKER = "unlazy"; // identifies our entries: command mentions unlazy + stop-hook.mjs
+const MARKER = "unlazy"; // passed to the hook as an ignored argv tag, so identification
+                         // never depends on the skill living in a path named "unlazy"
+                         // (an argument, not a shell comment: cmd.exe has no "#")
 
 const target = global_
   ? join(homedir(), ".claude", "settings.json")
@@ -43,7 +45,9 @@ const stopHooks = Array.isArray(settings.hooks.Stop) ? settings.hooks.Stop : [];
 const isOurs = (entry) =>
   Array.isArray(entry?.hooks) &&
   entry.hooks.some(h => typeof h?.command === "string" &&
-    h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER));
+    h.command.includes("stop-hook.mjs") &&
+    // marker in the command, or, for entries written before it existed, our own path
+    (h.command.toLowerCase().includes(MARKER) || h.command.includes(hookScript)));
 
 const kept = stopHooks.filter(e => !isOurs(e));
 
@@ -63,7 +67,7 @@ if (uninstall) {
 const entry = {
   hooks: [{
     type: "command",
-    command: `node "${hookScript}"`,
+    command: `node "${hookScript}" --${MARKER}`,
     timeout: 20,
   }],
 };
@@ -78,7 +82,7 @@ mkdirSync(dirname(target), { recursive: true });
 writeFileSync(target, JSON.stringify(settings, null, 2) + "\n");
 
 console.log(`Installed unlazy Stop hook into ${target}
-  command: node "${hookScript}"
+  command: node "${hookScript}" --${MARKER}
   effect:  while GATES.md or gates/*.md in the working directory contain unmet
            gates, ending the turn is blocked (max 6 blocks without progress,
            ABANDON lines are honored as an honest exit).

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -49,6 +49,13 @@ const isOurs = (entry) =>
     // marker in the command, or, for entries written before it existed, our own path
     (h.command.toLowerCase().includes(MARKER) || h.command.includes(hookScript)));
 
+// Ours AND still pointing at this copy of the script. An entry left behind by
+// an install that has since moved is ours, but stale: it must be replaced, not
+// reported as already installed, or enforcement is silently off.
+const isCurrent = (entry) =>
+  Array.isArray(entry?.hooks) &&
+  entry.hooks.some(h => typeof h?.command === "string" && h.command.includes(hookScript));
+
 const kept = stopHooks.filter(e => !isOurs(e));
 
 if (uninstall) {
@@ -72,7 +79,7 @@ const entry = {
   }],
 };
 
-if (stopHooks.some(isOurs)) {
+if (stopHooks.some(isCurrent)) {
   console.log(`Already installed in ${target} (idempotent, nothing changed).`);
   process.exit(0);
 }

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -7,9 +7,11 @@
 //   node install-hooks.mjs               install into project settings.local.json
 //   node install-hooks.mjs --shared      install into project settings.json (tracked)
 //   node install-hooks.mjs --global      install into ~/.claude/settings.json
+//   node install-hooks.mjs --scope api   guard only the .unlazy/api/ pipeline
 //   node install-hooks.mjs --uninstall   remove from the chosen target (same flags)
 //
-// Idempotent: running install twice changes nothing.
+// Idempotent: running install twice changes nothing. Re-running with a
+// different --scope replaces the existing entry rather than stacking a second.
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -20,6 +22,12 @@ const args = process.argv.slice(2);
 const uninstall = args.includes("--uninstall");
 const global_ = args.includes("--global");
 const shared = args.includes("--shared");
+const scopeIdx = args.indexOf("--scope");
+const scope = scopeIdx !== -1 ? args[scopeIdx + 1] : null;
+if (scopeIdx !== -1 && !scope) {
+  console.error("--scope needs a pipeline id");
+  process.exit(1);
+}
 
 const hookScript = join(dirname(fileURLToPath(import.meta.url)), "stop-hook.mjs");
 const MARKER = "unlazy"; // passed to the hook as an ignored argv tag, so identification
@@ -71,15 +79,14 @@ if (uninstall) {
   process.exit(0);
 }
 
-const entry = {
-  hooks: [{
-    type: "command",
-    command: `node "${hookScript}" --${MARKER}`,
-    timeout: 20,
-  }],
-};
+const command = `node "${hookScript}" --${MARKER}` + (scope ? ` --scope ${scope}` : "");
+const entry = { hooks: [{ type: "command", command, timeout: 20 }] };
 
-if (stopHooks.some(isCurrent)) {
+// isCurrent already rejects an entry left by a moved install. Comparing the
+// whole command additionally requires the same --scope, so re-pinning the hook
+// to a different pipeline replaces the entry instead of being reported as
+// already installed and silently guarding the wrong one.
+if (stopHooks.some(e => isCurrent(e) && e.hooks.some(h => h.command === command))) {
   console.log(`Already installed in ${target} (idempotent, nothing changed).`);
   process.exit(0);
 }
@@ -89,9 +96,11 @@ mkdirSync(dirname(target), { recursive: true });
 writeFileSync(target, JSON.stringify(settings, null, 2) + "\n");
 
 console.log(`Installed unlazy Stop hook into ${target}
-  command: node "${hookScript}" --${MARKER}
-  effect:  while GATES.md or gates/*.md in the working directory contain unmet
-           gates, ending the turn is blocked (max 6 blocks without progress,
-           ABANDON lines are honored as an honest exit).
+  command: ${command}
+  effect:  while ${scope ? `the .unlazy/${scope}/ pipeline has` : "this session's pipeline has"} unmet gates, ending the turn is
+           blocked (max 6 blocks without progress, ABANDON lines are honored
+           as an honest exit). A pipeline this session does not own never
+           blocks it.
+  scope:   ${scope ? `pinned to ${scope}` : "resolved per run: UNLAZY_SCOPE, then the session binding in .unlazy/<id>/session, then the only pipeline present, then legacy GATES.md"}
   remove:  node "${fileURLToPath(import.meta.url)}"${global_ ? " --global" : shared ? " --shared" : ""} --uninstall
-  note:    add .unlazy-hook-state.json to your .gitignore`);
+  note:    add .unlazy/ (or .unlazy-hook-state.json in legacy layout) to .gitignore`);

--- a/scripts/lib/gates.mjs
+++ b/scripts/lib/gates.mjs
@@ -1,0 +1,337 @@
+// gates.mjs : the single source of truth for gate parsing, scope resolution,
+// locking and lease bookkeeping. Both gate-check.mjs and stop-hook.mjs import
+// this, so they can never disagree about what a gate is or which pipeline it
+// belongs to. Zero dependencies. Node 18+.
+
+import {
+  readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync,
+  openSync, closeSync, unlinkSync, renameSync, appendFileSync, statSync,
+} from "node:fs";
+import { join, dirname, basename, resolve } from "node:path";
+import { createHash } from "node:crypto";
+
+export const UNLAZY_DIR = ".unlazy";
+export const LOCK_DIR = join(UNLAZY_DIR, "locks");
+
+export const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+// ---------------------------------------------------------------- parsing
+
+const GATE_RE = /^- \[( |x|X)\] (.*)$/;
+const ATTR_RE = /^\s+(CHECK|EXPECT|EVIDENCE|CWD):\s?(.*)$/;
+const HEADER_RE = /^(OWNS):\s*(.*)$/;
+const ABANDON_RE = /^ABANDON:\s*(\S+)\s*(.*)$/;
+
+// Parse a gate file's text. One implementation, used everywhere, so a gate's
+// id is the same string no matter which tool is looking at it.
+export function parseGates(text) {
+  const lines = text.split(/\r?\n/);
+  const gates = [];
+  const abandoned = new Map();
+  const owns = [];
+  let cur = null;
+  let seenGate = false;
+
+  lines.forEach((line, i) => {
+    const g = line.match(GATE_RE);
+    if (g) {
+      seenGate = true;
+      const title = g[2].trim();
+      cur = {
+        line: i,
+        checked: g[1].toLowerCase() === "x",
+        // Deterministic id: the "Gn:" prefix when present, else the line
+        // number. Shared by every tool, so ABANDON always resolves.
+        id: (title.match(/^(\S+?):/) || [null, "L" + (i + 1)])[1],
+        title: title.replace(/^\S+?:\s*/, ""),
+        check: null, expect: null, evidence: null, evidenceLine: -1,
+        cwd: null,
+      };
+      gates.push(cur);
+      return;
+    }
+    const a = cur && line.match(ATTR_RE);
+    if (a) {
+      const key = a[1].toLowerCase();
+      const val = a[2].trim();
+      if (key === "evidence") { cur.evidence = val; cur.evidenceLine = i; }
+      else cur[key] = val;
+      return;
+    }
+    const ab = line.match(ABANDON_RE);
+    if (ab) { abandoned.set(ab[1].replace(/:$/, ""), ab[2] || "(no reason)"); return; }
+    // Header directives are only meaningful before the first gate.
+    if (!seenGate) {
+      const h = line.match(HEADER_RE);
+      if (h) {
+        owns.push(...h[2].split(",").map(s => s.trim()).filter(Boolean));
+        return;
+      }
+    }
+    if (/^#|^- /.test(line)) cur = null;
+  });
+
+  return { lines, gates, abandoned, owns };
+}
+
+// A gate's fully-qualified id: "leaf-1.2.1:G3". Unique across a whole tree.
+export function qualify(fileOrLabel, id) {
+  const stem = basename(String(fileOrLabel)).replace(/\.md$/i, "");
+  return stem + ":" + id;
+}
+
+// UNMET = unchecked, or checked while EVIDENCE still reads "pending".
+export function gateState(gate, abandoned) {
+  if (abandoned.has(gate.id)) return "abandoned";
+  const pending = gate.evidence === null || /^pending$/i.test(gate.evidence);
+  if (!gate.checked) return "unmet";
+  if (pending) return "unmet-no-evidence";
+  return "met";
+}
+
+export function expectMatches(expect, output) {
+  const rx = expect.match(/^\/(.+)\/([a-z]*)$/);
+  if (rx) {
+    try { return new RegExp(rx[1], rx[2]).test(output); } catch { return false; }
+  }
+  return output.includes(expect);
+}
+
+export function tail(output, max = 200) {
+  const ls = output.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+  return (ls.slice(-2).join(" | ") || "(no output)").slice(0, max);
+}
+
+// ------------------------------------------------------------------ scope
+
+export function scopeRoot(root, scope) { return join(root, UNLAZY_DIR, scope); }
+
+export function listScopes(root) {
+  const dir = join(root, UNLAZY_DIR);
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter(d => d.isDirectory() && d.name !== "locks")
+      .map(d => d.name)
+      .sort();
+  } catch { return []; }
+}
+
+function mdFiles(dir) {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir).filter(f => f.endsWith(".md")).sort().map(f => join(dir, f));
+  } catch { return []; }
+}
+
+// Every gate file belonging to one scope. Never reaches outside it.
+export function scopeFiles(root, scope) {
+  const base = scopeRoot(root, scope);
+  const out = [];
+  const top = join(base, "GATES.md");
+  if (existsSync(top)) out.push(top);
+  out.push(...mdFiles(join(base, "gates")));
+  return out;
+}
+
+// Legacy single-pipeline layout: GATES.md + gates/*.md directly under cwd.
+export function legacyFiles(root) {
+  const out = [];
+  const top = join(root, "GATES.md");
+  if (existsSync(top)) out.push(top);
+  out.push(...mdFiles(join(root, "gates")));
+  return out;
+}
+
+// Decide which pipeline we are looking at. Refuses to guess when more than one
+// scope exists: silently globbing every pipeline's gates is the bug this whole
+// layout exists to prevent.
+//
+// Returns { mode, scope, files, error? }
+//   mode: "explicit" | "scope" | "legacy" | "none"
+export function resolveTarget(opts = {}) {
+  const root = opts.root || process.cwd();
+  const files = opts.files || [];
+  const sessionId = opts.sessionId || null;
+
+  if (files.length) {
+    return { mode: "explicit", scope: null, files: files.map(f => resolve(root, f)) };
+  }
+
+  const scopes = listScopes(root);
+  const wanted = opts.scope || process.env.UNLAZY_SCOPE || null;
+
+  if (wanted) {
+    if (!scopes.includes(wanted)) {
+      return {
+        mode: "none", scope: wanted, files: [],
+        error: 'no such scope "' + wanted + '" under ' + UNLAZY_DIR + "/ (have: " +
+          (scopes.join(", ") || "none") + ")",
+      };
+    }
+    return { mode: "scope", scope: wanted, files: scopeFiles(root, wanted) };
+  }
+
+  if (scopes.length === 1) {
+    return { mode: "scope", scope: scopes[0], files: scopeFiles(root, scopes[0]) };
+  }
+
+  if (scopes.length > 1) {
+    // A session binds itself to a scope by writing its id into
+    // .unlazy/<scope>/session; that is how a Stop hook knows whose gates it is
+    // guarding when several pipelines share one working copy.
+    if (sessionId) {
+      const owned = scopes.filter(s => {
+        try {
+          return readFileSync(join(scopeRoot(root, s), "session"), "utf8").trim() ===
+            String(sessionId).trim();
+        } catch { return false; }
+      });
+      if (owned.length === 1) {
+        return { mode: "scope", scope: owned[0], files: scopeFiles(root, owned[0]) };
+      }
+    }
+    return {
+      mode: "none", scope: null, files: [], ambiguous: scopes,
+      error: scopes.length + " pipelines present (" + scopes.join(", ") +
+        "); pass --scope <id> or set UNLAZY_SCOPE. Refusing to run every " +
+        "pipeline's checks at once.",
+    };
+  }
+
+  const legacy = legacyFiles(root);
+  if (legacy.length) return { mode: "legacy", scope: null, files: legacy };
+  return { mode: "none", scope: null, files: [] };
+}
+
+export function statusLogPath(root, scope) {
+  return scope ? join(scopeRoot(root, scope), "status.log") : join(root, "unlazy-status.log");
+}
+
+export function appendStatus(root, scope, line) {
+  const p = statusLogPath(root, scope);
+  mkdirSync(dirname(p), { recursive: true });
+  // Append, never read-modify-write: concurrent leaves cannot lose each
+  // other's lines, and the stable prefix stays cache-friendly.
+  appendFileSync(p, line.replace(/\r?\n/g, " ") + "\n");
+  return p;
+}
+
+export function hookStatePath(root, scope) {
+  return scope
+    ? join(scopeRoot(root, scope), "hook-state.json")
+    : join(root, ".unlazy-hook-state.json");
+}
+
+// ------------------------------------------------------------------- locks
+
+const hash = (s) => createHash("sha256").update(s).digest("hex").slice(0, 16);
+
+function lockDir(root) {
+  const d = join(root, LOCK_DIR);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+// Exclusive lock via open(..., "wx"), which is atomic create-if-absent on both
+// NTFS and POSIX. Breaks locks older than staleMs so a killed process cannot
+// wedge a pipeline forever.
+export async function withFileLock(root, target, fn, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  const staleMs = opts.staleMs ?? 300000;
+  const lock = join(lockDir(root), hash(resolve(target)) + ".filelock");
+  const deadline = Date.now() + timeoutMs;
+  let fd = null;
+  for (;;) {
+    try { fd = openSync(lock, "wx"); break; }
+    catch (e) {
+      if (e.code !== "EEXIST") throw e;
+      let age = Infinity;
+      try { age = Date.now() - statSync(lock).mtimeMs; } catch { age = Infinity; }
+      if (age > staleMs) { try { unlinkSync(lock); } catch { /* raced */ } continue; }
+      if (Date.now() > deadline) throw new Error("timed out waiting for lock on " + target);
+      await sleep(50 + Math.floor(Math.random() * 100));
+    }
+  }
+  try { writeFileSync(fd, JSON.stringify({ pid: process.pid, target: resolve(target) })); }
+  catch { /* advisory content only */ }
+  try { return await fn(); }
+  finally {
+    try { closeSync(fd); } catch { /* ignore */ }
+    try { unlinkSync(lock); } catch { /* ignore */ }
+  }
+}
+
+// Write via tmp + rename so a reader never sees a half-written gate file.
+export function writeAtomic(file, text) {
+  const tmp = file + "." + process.pid + ".tmp";
+  writeFileSync(tmp, text);
+  renameSync(tmp, file); // replaces the destination on NTFS and POSIX alike
+}
+
+// ------------------------------------------------------------------ leases
+
+// Conservative overlap test on the literal prefix of each glob. It can report a
+// conflict that a full glob intersection would clear (never the reverse), which
+// is the safe direction for a tool whose job is stopping two leaves from
+// writing the same file.
+export function literalPrefix(glob) {
+  const g = String(glob).replace(/\\/g, "/").replace(/^\.\//, "");
+  const i = g.search(/[*?[{]/);
+  return (i === -1 ? g : g.slice(0, i)).replace(/\/+$/, "");
+}
+
+export function globsOverlap(a, b) {
+  const pa = literalPrefix(a), pb = literalPrefix(b);
+  if (!pa || !pb) return true; // one side claims the whole tree
+  return pa === pb || pa.startsWith(pb + "/") || pb.startsWith(pa + "/");
+}
+
+export function readLeases(root) {
+  const d = join(root, LOCK_DIR);
+  if (!existsSync(d)) return [];
+  const out = [];
+  for (const f of readdirSync(d)) {
+    if (!f.endsWith(".lease")) continue;
+    try {
+      out.push(Object.assign({ file: join(d, f) },
+        JSON.parse(readFileSync(join(d, f), "utf8"))));
+    } catch { /* skip unreadable */ }
+  }
+  return out;
+}
+
+// Claim ownership of every glob a gate file declares. Either all claims
+// succeed or nothing is written, so a refused claim cannot half-lock a tree.
+export function claimLeases(root, spec) {
+  const { scope, leaf, globs } = spec;
+  const held = readLeases(root);
+  const conflicts = [];
+  for (const g of globs) {
+    for (const h of held) {
+      if (h.scope === scope && h.leaf === leaf) continue; // our own, re-claiming
+      const clash = (h.globs || []).find(hg => globsOverlap(g, hg));
+      if (clash) conflicts.push({ glob: g, with: h.scope + "/" + h.leaf, theirGlob: clash });
+    }
+  }
+  if (conflicts.length) return { ok: false, conflicts };
+
+  const file = join(lockDir(root), hash(scope + "::" + leaf) + ".lease");
+  try {
+    writeAtomic(file, JSON.stringify({ scope, leaf, globs, pid: process.pid }, null, 2));
+  } catch (e) {
+    return { ok: false, conflicts: [], error: e.message };
+  }
+  return { ok: true, file, conflicts: [] };
+}
+
+export function releaseLeases(root, spec) {
+  const { scope, leaf = null } = spec;
+  let n = 0;
+  for (const l of readLeases(root)) {
+    if (l.scope !== scope) continue;
+    if (leaf && l.leaf !== leaf) continue;
+    try { unlinkSync(l.file); n++; } catch { /* ignore */ }
+  }
+  return n;
+}

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -15,6 +15,9 @@
 // Progress = the combined content of the gate files changed since last block.
 // State lives in .unlazy-hook-state.json next to the gates (add to .gitignore).
 //
+// Argv is ignored. The installer appends "--unlazy" so its own entries stay
+// identifiable in settings without depending on the install path.
+//
 // Contract (docs: code.claude.com/docs/en/hooks):
 //   stdin  JSON with { cwd, stop_hook_active, ... }
 //   stdout {"decision":"block","reason":"..."} + exit 0 to block; exit 0 silent to allow.

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -1,100 +1,94 @@
 #!/usr/bin/env node
-// stop-hook.mjs : Claude Code Stop hook for the unlazy skill (v2).
+// stop-hook.mjs : Claude Code Stop hook for the unlazy skill (v2.1).
 //
-// Structurally blocks ending the turn while GATES.md / gates/*.md contain
-// unmet gates. Zero tokens: this is a file scan, not a model call.
+// Structurally blocks ending the turn while THIS pipeline's gates are unmet.
+// Zero tokens: a file scan, not a model call.
+//
+// Usage in a Stop hook command:
+//   node stop-hook.mjs                  guard whichever pipeline this session owns
+//   node stop-hook.mjs --scope api      guard .unlazy/api/ specifically
+//
+// Only --scope is read. Any other argument is ignored, including the "--unlazy"
+// tag the installer appends so its own entries stay identifiable in settings
+// without depending on the install path.
+//
+// Scope resolution, in order: --scope, UNLAZY_SCOPE, the session binding in
+// .unlazy/<scope>/session, the only pipeline present, else the legacy
+// GATES.md + gates/*.md layout under cwd.
 //
 // Behavior:
-//   - No gate files in cwd            -> allow (skill not active here)
-//   - All gates met or abandoned      -> allow
-//   - Unmet gates, progress happening -> block with a one-line reason
-//   - Unmet gates, NO progress after MAX_BLOCKS consecutive blocks -> allow
-//     with a warning (never traps a genuinely stuck agent; Claude Code
-//     additionally force-releases after 8 consecutive blocks)
+//   - No gate files                       -> allow (skill not active here)
+//   - Scope cannot be resolved            -> allow, with a note. A session is
+//     never blocked by a pipeline it does not own; that is the whole point of
+//     scoping, and blocking on someone else's work is unactionable.
+//   - All gates met or abandoned          -> allow
+//   - Unmet gates, progress happening     -> block, naming file-qualified ids
+//   - Unmet gates, no progress after MAX_BLOCKS consecutive blocks -> allow
+//     with a warning (never traps a genuinely stuck agent; Claude Code also
+//     force-releases after 8 consecutive blocks)
 //
-// Progress = the combined content of the gate files changed since last block.
-// State lives in .unlazy-hook-state.json next to the gates (add to .gitignore).
-//
-// Argv is ignored. The installer appends "--unlazy" so its own entries stay
-// identifiable in settings without depending on the install path.
+// Progress = this scope's gate files changed since the last block. The counter
+// lives in .unlazy/<scope>/hook-state.json, one per pipeline, so pipelines
+// cannot reset or exhaust each other's loop guard.
 //
 // Contract (docs: code.claude.com/docs/en/hooks):
-//   stdin  JSON with { cwd, stop_hook_active, ... }
-//   stdout {"decision":"block","reason":"..."} + exit 0 to block; exit 0 silent to allow.
+//   stdin  JSON with { cwd, session_id, stop_hook_active, ... }
+//   stdout {"decision":"block","reason":"..."} + exit 0 to block;
+//          exit 0 with no output to allow.
 
-import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
+import {
+  parseGates, qualify, gateState, resolveTarget, hookStatePath, UNLAZY_DIR,
+} from "./lib/gates.mjs";
 
 const MAX_BLOCKS = 6;
 
-function readStdin() {
-  try { return readFileSync(0, "utf8"); } catch { return "{}"; }
-}
+const args = process.argv.slice(2);
+const scopeArg = (() => {
+  const i = args.indexOf("--scope");
+  return i !== -1 ? args[i + 1] : null;
+})();
 
 let payload = {};
-try { payload = JSON.parse(readStdin() || "{}"); } catch { /* stay permissive */ }
-const cwd = payload.cwd || process.cwd();
+try { payload = JSON.parse(readFileSync(0, "utf8") || "{}"); } catch { /* stay permissive */ }
+const root = payload.cwd || process.cwd();
+const sessionId = payload.session_id || payload.sessionId || null;
 
-function gateFiles(dir) {
-  const found = [];
-  const top = join(dir, "GATES.md");
-  if (existsSync(top)) found.push(top);
-  const gdir = join(dir, "gates");
-  if (existsSync(gdir)) {
-    try {
-      for (const f of readdirSync(gdir)) if (f.endsWith(".md")) found.push(join(gdir, f));
-    } catch { /* ignore */ }
-  }
-  return found;
+const allow = (msg) => {
+  if (msg) console.log(JSON.stringify({ systemMessage: msg }));
+  process.exit(0);
+};
+
+const target = resolveTarget({ root, scope: scopeArg, sessionId });
+
+if (target.ambiguous) {
+  allow("unlazy: " + target.ambiguous.length + " pipelines under " + UNLAZY_DIR +
+    "/ (" + target.ambiguous.join(", ") + ") and none bound to this session; " +
+    "not blocking. Bind one with UNLAZY_SCOPE or install the hook with --scope <id>.");
 }
-
-const files = gateFiles(cwd);
-if (!files.length) process.exit(0); // no gates, nothing to enforce
-
-const GATE_RE = /^- \[( |x|X)\] (.*)$/;
-const EVIDENCE_RE = /^\s+EVIDENCE:\s?(.*)$/;
-const ABANDON_RE = /^ABANDON:\s*(\S+)/;
+if (target.error || !target.files.length) allow(null);
 
 let combined = "";
 const unmet = [];
 
-for (const file of files) {
+for (const file of target.files) {
   let text = "";
   try { text = readFileSync(file, "utf8"); } catch { continue; }
   combined += text;
-  const lines = text.split(/\r?\n/);
-  const abandoned = new Set(
-    lines.map(l => (l.match(ABANDON_RE) || [])[1]).filter(Boolean).map(s => s.replace(/:$/, ""))
-  );
-  let cur = null; // { id, checked, evidence }
-  const flush = () => {
-    if (!cur || abandoned.has(cur.id)) { cur = null; return; }
-    const pending = cur.evidence === null || /^pending$/i.test(cur.evidence);
-    if (!cur.checked || pending) unmet.push(cur.id);
-    cur = null;
-  };
-  for (const line of lines) {
-    const g = line.match(GATE_RE);
-    if (g) {
-      flush();
-      cur = {
-        checked: g[1].toLowerCase() === "x",
-        id: (g[2].match(/^(\S+?):/) || [null, g[2].trim().slice(0, 24)])[1],
-        evidence: null,
-      };
-      continue;
-    }
-    const ev = cur && line.match(EVIDENCE_RE);
-    if (ev) cur.evidence = ev[1].trim();
+  const doc = parseGates(text);
+  for (const g of doc.gates) {
+    const st = gateState(g, doc.abandoned);
+    // Qualified ids: "G1" alone is ambiguous the moment a tree has more than
+    // one gate file, which makes an otherwise correct block unactionable.
+    if (st === "unmet" || st === "unmet-no-evidence") unmet.push(qualify(file, g.id));
   }
-  flush();
 }
 
 if (!unmet.length) process.exit(0); // everything met or honestly abandoned
 
-// Progress-aware loop guard.
-const statePath = join(cwd, ".unlazy-hook-state.json");
+// Progress-aware loop guard, per pipeline.
+const statePath = hookStatePath(root, target.scope);
 const hash = createHash("sha256").update(combined).digest("hex").slice(0, 16);
 let state = { hash: "", blocks: 0 };
 try { state = JSON.parse(readFileSync(statePath, "utf8")); } catch { /* fresh */ }
@@ -102,17 +96,21 @@ if (state.hash !== hash) state = { hash, blocks: 0 }; // progress -> reset count
 state.blocks += 1;
 try { writeFileSync(statePath, JSON.stringify(state)); } catch { /* non-fatal */ }
 
+const where = target.scope ? " [scope " + target.scope + "]" : "";
+
 if (state.blocks > MAX_BLOCKS) {
-  // No progress across MAX_BLOCKS consecutive stops: release rather than trap.
-  console.log(JSON.stringify({
-    systemMessage: `unlazy: releasing after ${MAX_BLOCKS} blocks without gate progress; ${unmet.length} gates remain unmet (${unmet.slice(0, 4).join(", ")}).`,
-  }));
-  process.exit(0);
+  allow("unlazy: releasing after " + MAX_BLOCKS + " blocks without gate progress" +
+    where + "; " + unmet.length + " gates remain unmet (" + unmet.slice(0, 4).join(", ") + ").");
 }
 
-const list = unmet.slice(0, 5).join(", ") + (unmet.length > 5 ? `, +${unmet.length - 5} more` : "");
+const list = unmet.slice(0, 5).join(", ") +
+  (unmet.length > 5 ? ", +" + (unmet.length - 5) + " more" : "");
 console.log(JSON.stringify({
   decision: "block",
-  reason: `unlazy: ${unmet.length} gate(s) unmet: ${list}. Work the next unchecked gate (run gate-check.mjs to execute CHECK lines), or add "ABANDON: <id> <reason>" if one is genuinely impossible. Done means every box checked with evidence.`,
+  reason: "unlazy" + where + ": " + unmet.length + " gate(s) unmet: " + list +
+    '. Work the next unchecked gate (run gate-check.mjs' +
+    (target.scope ? " --scope " + target.scope : "") +
+    ' to execute CHECK lines), or add "ABANDON: <id> <reason>" if one is ' +
+    "genuinely impossible. Done means every box checked with evidence.",
 }));
 process.exit(0);

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -1,5 +1,6 @@
 # Plan: <task>
 
+Scope: <pipeline id; this file lives at .unlazy/<scope>/PLAN.md>
 Depth: tree <N>   Mode: orchestrated
 Budget note: <what a competent single pass would take; context, not arithmetic>
 
@@ -8,10 +9,15 @@ Budget note: <what a competent single pass would take; context, not arithmetic>
 Decided BEFORE fan-out. Everything a leaf could get wrong about its neighbors:
 
 - Interfaces: <function signatures, file formats, API shapes>
-- Data ownership: <which leaf owns which files; no two leaves share a file>
+- Data ownership: <which leaf owns which files; no two leaves share a file.
+  Each leaf repeats its share as an OWNS: header in its own gates file, so the
+  claim is checked by --claim rather than trusted>
 - Naming and conventions: <casing, folder layout, error handling style>
 
 ## Tree
+
+Each leaf's gates file carries its own `OWNS:` header, so ownership is claimed
+and checked per leaf rather than trusted from this table.
 
 - 1 <task>
   - 1.1 <branch> .......... gates/node-1.1.md
@@ -23,7 +29,12 @@ Decided BEFORE fan-out. Everything a leaf could get wrong about its neighbors:
 
 ## Status log
 
-Append-only. One line per event: leaf started, leaf verified, gate abandoned.
-Never rewrite lines above; appending keeps the file cheap to re-read and diff.
+The log lives in `.unlazy/<scope>/status.log`, not in this file, and is appended
+to one line at a time:
 
-- <timestamp or step> plan written, contract fixed
+```
+node <skill-dir>/scripts/gate-check.mjs --scope <scope> --log "leaf-1.1.1 verified, 7/7"
+```
+
+Appending instead of rewriting is what makes it safe for several leaves to
+report at once, and keeps the stable prefix cheap to re-read.

--- a/templates/gates-leaf.md
+++ b/templates/gates-leaf.md
@@ -1,5 +1,7 @@
 # Gates: <leaf or task name>
 
+OWNS: <globs this leaf may write, e.g. src/api/**, tests/api/*.test.ts>
+
 Scope: <one line: what this unit of work delivers>
 
 - [ ] G1: <observable outcome, stated so a stranger could judge it>
@@ -7,9 +9,10 @@ Scope: <one line: what this unit of work delivers>
   EXPECT: <substring the command output must contain, or /regex/>
   EVIDENCE: pending
 
-- [ ] G2: <another runnable outcome>
+- [ ] G2: <an outcome proven somewhere other than the root>
   CHECK: <command>
-  EXPECT: <substring or /regex/>
+  EXPECT: <the line that can only appear on success>
+  CWD: <subdirectory>
   EVIDENCE: pending
 
 - [ ] G3: <manual gate, when no command can prove it>
@@ -21,6 +24,11 @@ Rules (full spec in references/gates.md):
   matches EXPECT, or by hand for manual gates.
 - A checked box with EVIDENCE still reading "pending" counts as UNMET.
 - Evidence is the deciding lines only, never a full log.
+- EXPECT must match a line that can only appear on success. "done" appears
+  either way; "8/8 passed" does not.
+- CWD: <dir> runs one check somewhere other than the root.
+- OWNS is only needed when leaves run in parallel: it makes file ownership
+  checkable via --claim instead of promised in PLAN.md. See references/parallel.md.
 - If a gate becomes impossible, do not delete it. Add a line:
     ABANDON: G<n> <reason>
   and report it. Visible surrender is honest; silent scope-narrowing is not.

--- a/templates/gates-node.md
+++ b/templates/gates-node.md
@@ -3,7 +3,7 @@
 Scope: children <list child leaves/branches> merged into one working whole
 
 - [ ] N1: every child leaf's gates file is fully checked (no unchecked boxes, no pending evidence)
-  CHECK: node <skill-dir>/scripts/gate-check.mjs --status gates/leaf-<a>.md gates/leaf-<b>.md
+  CHECK: node <skill-dir>/scripts/gate-check.mjs --status .unlazy/<scope>/gates/leaf-<a>.md .unlazy/<scope>/gates/leaf-<b>.md
   EXPECT: ALL MET
   EVIDENCE: pending
 
@@ -22,8 +22,19 @@ Scope: children <list child leaves/branches> merged into one working whole
   EXPECT: <success marker>
   EVIDENCE: pending
 
+- [ ] N5: no leaf still holds a file-ownership lease from this branch
+  CHECK: node <skill-dir>/scripts/gate-check.mjs --scope <scope> --release
+  EXPECT: released
+  EVIDENCE: pending
+
 <!--
 Branch gates exist because finished parts do not imply a finished whole.
 Do not mark N1 by trusting child reports: re-run their checks yourself
 (verification hierarchy, references/orchestration.md).
+
+N1 names its children explicitly rather than relying on discovery, so a child
+added later cannot slip past this gate unnoticed. Naming files also keeps the
+check inside this branch: an unqualified run would cover the whole pipeline.
+
+Drop N5 if this branch's leaves never claimed ownership.
 -->

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+// run-tests.mjs : behavioural tests for the unlazy enforcement scripts.
+// Zero dependencies, cross-platform (every CHECK command is a `node -e`).
+//
+//   node tests/run-tests.mjs            run all
+//   node tests/run-tests.mjs scope      run tests whose name contains "scope"
+//
+// Prints "N/N passed" on success, which is the string CI and the repo's own
+// gates match on.
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE_CHECK = join(HERE, "..", "scripts", "gate-check.mjs");
+const STOP_HOOK = join(HERE, "..", "scripts", "stop-hook.mjs");
+const INSTALL = join(HERE, "..", "scripts", "install-hooks.mjs");
+const filter = process.argv[2] || "";
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+
+// ------------------------------------------------------------- helpers
+
+function sandbox() {
+  const dir = mkdtempSync(join(tmpdir(), "unlazy-test-"));
+  return {
+    dir,
+    write(rel, text) {
+      const p = join(dir, rel);
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, text);
+      return p;
+    },
+    read(rel) { return readFileSync(join(dir, rel), "utf8"); },
+    cleanup() { try { rmSync(dir, { recursive: true, force: true }); } catch { /* windows lag */ } },
+  };
+}
+
+function run(script, args, opts = {}) {
+  return new Promise((res) => {
+    const child = execFile(process.execPath, [script, ...args], {
+      cwd: opts.cwd, encoding: "utf8", maxBuffer: 8 * 1024 * 1024,
+      env: { ...process.env, ...(opts.env || {}) },
+    }, (err, stdout, stderr) => {
+      res({ code: err ? (err.code ?? 1) : 0, out: (stdout || "") + (stderr || "") });
+    });
+    if (opts.stdin !== undefined) { child.stdin.end(opts.stdin); }
+  });
+}
+
+const gate = (id, title, check, expect) =>
+  "- [ ] " + id + ": " + title + "\n" +
+  (check ? "  CHECK: " + check + "\n" : "") +
+  (expect ? "  EXPECT: " + expect + "\n" : "") +
+  "  EVIDENCE: pending\n";
+
+const nodeEval = (js) => 'node -e "' + js.replace(/"/g, '\\"') + '"';
+const echoOk = (word) => nodeEval("console.log('" + word + "')");
+
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+function assertHas(hay, needle, label) {
+  assert(hay.includes(needle), (label || "output") + " missing " + JSON.stringify(needle) + "\n--- got ---\n" + hay);
+}
+function assertLacks(hay, needle, label) {
+  assert(!hay.includes(needle), (label || "output") + " unexpectedly contains " + JSON.stringify(needle) + "\n--- got ---\n" + hay);
+}
+
+// --------------------------------------------------------------- tests
+
+test("args: two explicit files are both processed without --timeout", async () => {
+  const s = sandbox();
+  try {
+    s.write("gates/leaf-a.md", "# Gates: A\n\n" + gate("G1", "A", echoOk("A-OK"), "A-OK"));
+    s.write("gates/leaf-b.md", "# Gates: B\n\n" + gate("G1", "B", echoOk("B-OK"), "B-OK"));
+    const r = await run(GATE_CHECK, ["gates/leaf-a.md", "gates/leaf-b.md"], { cwd: s.dir });
+    assertHas(r.out, "PASS leaf-a:G1");
+    assertHas(r.out, "PASS leaf-b:G1");
+    assertHas(r.out, "ALL MET (2 met)");
+    assertHas(s.read("gates/leaf-a.md"), "- [x] G1", "leaf-a");
+    assert(r.code === 0, "expected exit 0, got " + r.code);
+  } finally { s.cleanup(); }
+});
+
+test("args: one explicit file never widens to the rest of the tree", async () => {
+  const s = sandbox();
+  try {
+    s.write("gates/leaf-a.md", "# Gates: A\n\n" + gate("G1", "A", echoOk("A-OK"), "A-OK"));
+    s.write("gates/leaf-b.md", "# Gates: B\n\n" + gate("G1", "B", echoOk("B-OK"), "B-OK"));
+    const r = await run(GATE_CHECK, ["gates/leaf-a.md"], { cwd: s.dir });
+    assertHas(r.out, "PASS leaf-a:G1");
+    assertLacks(r.out, "leaf-b", "run output");
+    assertHas(s.read("gates/leaf-b.md"), "- [ ] G1", "leaf-b must be untouched");
+    assertHas(s.read("gates/leaf-b.md"), "EVIDENCE: pending", "leaf-b evidence must be untouched");
+  } finally { s.cleanup(); }
+});
+
+test("args: unknown option is rejected instead of treated as a file", async () => {
+  const s = sandbox();
+  try {
+    s.write("GATES.md", "# Gates\n\n" + gate("G1", "x", echoOk("OK"), "OK"));
+    const r = await run(GATE_CHECK, ["--nope"], { cwd: s.dir });
+    assert(r.code === 2, "expected exit 2, got " + r.code);
+    assertHas(r.out, "unknown option --nope");
+  } finally { s.cleanup(); }
+});
+
+test("scope: running one pipeline leaves the other pipeline alone", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates: api1\n\n" + gate("G1", "api", echoOk("API-OK"), "API-OK"));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates: web1\n\n" + gate("G1", "web", echoOk("WEB-OK"), "WEB-OK"));
+    const r = await run(GATE_CHECK, ["--scope", "api"], { cwd: s.dir });
+    assertHas(r.out, "PASS leaf-1:G1");
+    assertHas(r.out, "[scope api]");
+    assertHas(s.read(".unlazy/api/gates/leaf-1.md"), "- [x] G1", "api gates");
+    assertHas(s.read(".unlazy/web/gates/leaf-1.md"), "- [ ] G1", "web gates must be untouched");
+  } finally { s.cleanup(); }
+});
+
+test("scope: two pipelines and no scope is refused, not guessed", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates: api\n\n" + gate("G1", "api", echoOk("API-OK"), "API-OK"));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates: web\n\n" + gate("G1", "web", echoOk("WEB-OK"), "WEB-OK"));
+    const r = await run(GATE_CHECK, [], { cwd: s.dir });
+    assert(r.code === 2, "expected exit 2, got " + r.code);
+    assertHas(r.out, "2 pipelines present");
+    assertHas(r.out, "api");
+    assertHas(r.out, "web");
+    assertHas(s.read(".unlazy/api/gates/leaf-1.md"), "- [ ] G1", "api must be untouched");
+    assertHas(s.read(".unlazy/web/gates/leaf-1.md"), "- [ ] G1", "web must be untouched");
+  } finally { s.cleanup(); }
+});
+
+test("scope: UNLAZY_SCOPE selects the pipeline", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates: api\n\n" + gate("G1", "api", echoOk("API-OK"), "API-OK"));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates: web\n\n" + gate("G1", "web", echoOk("WEB-OK"), "WEB-OK"));
+    const r = await run(GATE_CHECK, [], { cwd: s.dir, env: { UNLAZY_SCOPE: "web" } });
+    assertHas(r.out, "[scope web]");
+    assertHas(s.read(".unlazy/web/gates/leaf-1.md"), "- [x] G1", "web gates");
+    assertHas(s.read(".unlazy/api/gates/leaf-1.md"), "- [ ] G1", "api must be untouched");
+  } finally { s.cleanup(); }
+});
+
+test("scope: a single pipeline needs no flag", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/solo/GATES.md", "# Gates: solo\n\n" + gate("G1", "solo", echoOk("S-OK"), "S-OK"));
+    const r = await run(GATE_CHECK, [], { cwd: s.dir });
+    assertHas(r.out, "ALL MET (1 met) [scope solo]");
+  } finally { s.cleanup(); }
+});
+
+test("scope: legacy GATES.md layout still works", async () => {
+  const s = sandbox();
+  try {
+    s.write("GATES.md", "# Gates\n\n" + gate("G1", "legacy", echoOk("L-OK"), "L-OK"));
+    const r = await run(GATE_CHECK, [], { cwd: s.dir });
+    assertHas(r.out, "PASS GATES:G1");
+    assertHas(r.out, "ALL MET (1 met)");
+  } finally { s.cleanup(); }
+});
+
+test("state: checked box with pending evidence counts as unmet", async () => {
+  const s = sandbox();
+  try {
+    s.write("GATES.md", "# Gates\n\n- [x] G1: claimed\n  EVIDENCE: pending\n");
+    const r = await run(GATE_CHECK, ["--status"], { cwd: s.dir });
+    assert(r.code === 1, "expected exit 1, got " + r.code);
+    assertHas(r.out, "UNMET GATES:G1 (checked but EVIDENCE pending)");
+  } finally { s.cleanup(); }
+});
+
+test("state: ABANDON resolves a gate honestly", async () => {
+  const s = sandbox();
+  try {
+    s.write("GATES.md", "# Gates\n\n- [ ] G1: impossible\n  EVIDENCE: pending\n\nABANDON: G1 upstream API removed\n");
+    const r = await run(GATE_CHECK, ["--status"], { cwd: s.dir });
+    assert(r.code === 0, "expected exit 0, got " + r.code);
+    assertHas(r.out, "1 abandoned");
+  } finally { s.cleanup(); }
+});
+
+test("state: unmet gates are reported with file-qualified ids", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates: 1\n\n" + gate("G1", "a", null, null));
+    s.write(".unlazy/api/gates/leaf-2.md", "# Gates: 2\n\n" + gate("G1", "b", null, null));
+    const r = await run(GATE_CHECK, ["--scope", "api", "--status"], { cwd: s.dir });
+    assertHas(r.out, "leaf-1:G1");
+    assertHas(r.out, "leaf-2:G1");
+  } finally { s.cleanup(); }
+});
+
+test("run: a concurrent edit to another gate in the same file survives", async () => {
+  const s = sandbox();
+  try {
+    // G1 is slow and will be flipped by gate-check; G2 is manual and gets its
+    // evidence filled in by hand while that check is still running.
+    s.write("GATES.md",
+      "# Gates\n\n" +
+      "- [ ] G1: slow\n  CHECK: " + nodeEval("setTimeout(()=>console.log('SLOW-OK'),2500)") +
+      "\n  EXPECT: SLOW-OK\n  EVIDENCE: pending\n\n" +
+      "- [ ] G2: manual\n  EVIDENCE: pending\n");
+    const running = run(GATE_CHECK, [], { cwd: s.dir });
+    await new Promise(r => setTimeout(r, 800));
+    const text = s.read("GATES.md")
+      .replace("- [ ] G2: manual\n  EVIDENCE: pending", "- [x] G2: manual\n  EVIDENCE: measured 47 rows, threadAnalysis.ts:88");
+    s.write("GATES.md", text);
+    await running;
+    const after = s.read("GATES.md");
+    assertHas(after, "- [x] G1", "G1 should be flipped by the checker");
+    assertHas(after, "measured 47 rows", "the hand edit to G2 must not be clobbered");
+    assertLacks(after, "G2: manual\n  EVIDENCE: pending", "G2 must not be reverted");
+  } finally { s.cleanup(); }
+});
+
+test("checks: CWD runs a check in the directory it names", async () => {
+  const s = sandbox();
+  try {
+    s.write("sub/marker.txt", "here\n");
+    s.write("GATES.md", "# Gates\n\n" +
+      "- [ ] G1: in sub\n  CHECK: " + nodeEval("console.log(require('fs').readFileSync('marker.txt','utf8'))") +
+      "\n  EXPECT: here\n  CWD: sub\n  EVIDENCE: pending\n");
+    const r = await run(GATE_CHECK, [], { cwd: s.dir });
+    assertHas(r.out, "ALL MET (1 met)");
+  } finally { s.cleanup(); }
+});
+
+test("leases: overlapping OWNS across pipelines is refused", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "OWNS: src/shared/**\n\n# Gates\n\n" + gate("G1", "a", null, null));
+    s.write(".unlazy/web/gates/leaf-1.md", "OWNS: src/shared/util.ts\n\n# Gates\n\n" + gate("G1", "b", null, null));
+    const a = await run(GATE_CHECK, ["--scope", "api", "--leaf", "leaf-1", "--claim"], { cwd: s.dir });
+    assertHas(a.out, "CLAIMED 1 path(s) for api/leaf-1");
+    const b = await run(GATE_CHECK, ["--scope", "web", "--leaf", "leaf-1", "--claim"], { cwd: s.dir });
+    assert(b.code === 3, "expected exit 3 on conflict, got " + b.code);
+    assertHas(b.out, "CONFLICT src/shared/util.ts overlaps src/shared/** held by api/leaf-1");
+    assertHas(b.out, "CLAIM REFUSED");
+  } finally { s.cleanup(); }
+});
+
+test("leases: disjoint OWNS both succeed, and release frees them", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "OWNS: src/api/**\n\n# Gates\n\n" + gate("G1", "a", null, null));
+    s.write(".unlazy/api/gates/leaf-2.md", "OWNS: src/web/**\n\n# Gates\n\n" + gate("G1", "b", null, null));
+    const a = await run(GATE_CHECK, ["--scope", "api", "--leaf", "leaf-1", "--claim"], { cwd: s.dir });
+    const b = await run(GATE_CHECK, ["--scope", "api", "--leaf", "leaf-2", "--claim"], { cwd: s.dir });
+    assert(a.code === 0 && b.code === 0, "disjoint claims should both succeed");
+    assertHas(b.out, "CLAIMED 1 path(s) for api/leaf-2");
+    const rel = await run(GATE_CHECK, ["--scope", "api", "--release"], { cwd: s.dir });
+    assertHas(rel.out, "released 2 lease(s)");
+  } finally { s.cleanup(); }
+});
+
+test("status log: appends, and appends survive concurrency", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "a", null, null));
+    await Promise.all([
+      run(GATE_CHECK, ["--scope", "api", "--log", "leaf-1 started"], { cwd: s.dir }),
+      run(GATE_CHECK, ["--scope", "api", "--log", "leaf-2 started"], { cwd: s.dir }),
+      run(GATE_CHECK, ["--scope", "api", "--log", "leaf-3 started"], { cwd: s.dir }),
+    ]);
+    const log = s.read(".unlazy/api/status.log");
+    for (const n of [1, 2, 3]) assertHas(log, "leaf-" + n + " started", "status log");
+  } finally { s.cleanup(); }
+});
+
+test("hook: does not block on a pipeline this session does not own", async () => {
+  const s = sandbox();
+  try {
+    // api is finished; web has never been started. Ending the api session must
+    // not be blocked by web's gates.
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n- [x] G1: done\n  EVIDENCE: measured, 8/8 passed\n");
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "not started", null, null));
+    const r = await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin: JSON.stringify({ cwd: s.dir }) });
+    assertLacks(r.out, '"decision":"block"', "hook");
+    assert(r.code === 0, "hook should exit 0");
+  } finally { s.cleanup(); }
+});
+
+test("hook: blocks on its own scope, naming qualified ids", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-7.md", "# Gates\n\n" + gate("G3", "unfinished", null, null));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates\n\n- [x] G1: done\n  EVIDENCE: proven\n");
+    const r = await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin: JSON.stringify({ cwd: s.dir }) });
+    assertHas(r.out, '"decision":"block"');
+    assertHas(r.out, "leaf-7:G3");
+    assertHas(r.out, "[scope api]");
+  } finally { s.cleanup(); }
+});
+
+test("hook: unresolvable scope allows the stop instead of blocking blindly", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "a", null, null));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "b", null, null));
+    const r = await run(STOP_HOOK, [], { cwd: s.dir, stdin: JSON.stringify({ cwd: s.dir }) });
+    assertLacks(r.out, '"decision":"block"', "hook");
+    assertHas(r.out, "2 pipelines");
+  } finally { s.cleanup(); }
+});
+
+test("hook: session binding resolves the scope among several", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "a", null, null));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "b", null, null));
+    const bind = await run(GATE_CHECK, ["--scope", "web", "--bind", "sess-abc"], { cwd: s.dir });
+    assertHas(bind.out, "bound session sess-abc to scope web");
+    const r = await run(STOP_HOOK, [], { cwd: s.dir, stdin: JSON.stringify({ cwd: s.dir, session_id: "sess-abc" }) });
+    assertHas(r.out, '"decision":"block"');
+    assertHas(r.out, "[scope web]");
+  } finally { s.cleanup(); }
+});
+
+test("hook: each pipeline keeps its own loop-guard counter", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "a", null, null));
+    s.write(".unlazy/web/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "b", null, null));
+    const stdin = JSON.stringify({ cwd: s.dir });
+    for (let i = 0; i < 7; i++) await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+    const apiState = JSON.parse(s.read(".unlazy/api/hook-state.json"));
+    assert(apiState.blocks === 7, "api counter should be 7, got " + apiState.blocks);
+    // api has exhausted its guard and now releases; web is untouched and still blocks.
+    const apiNow = await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+    assertHas(apiNow.out, "releasing after 6 blocks");
+    const webNow = await run(STOP_HOOK, ["--scope", "web"], { cwd: s.dir, stdin });
+    assertHas(webNow.out, '"decision":"block"');
+  } finally { s.cleanup(); }
+});
+
+test("hook: no gate files anywhere means silence", async () => {
+  const s = sandbox();
+  try {
+    const r = await run(STOP_HOOK, [], { cwd: s.dir, stdin: JSON.stringify({ cwd: s.dir }) });
+    assert(r.out.trim() === "", "expected no output, got: " + r.out);
+    assert(r.code === 0, "expected exit 0");
+  } finally { s.cleanup(); }
+});
+
+test("install: repeated install stays a single Stop entry", async () => {
+  const s = sandbox();
+  try {
+    await run(INSTALL, ["--scope", "api"], { cwd: s.dir });
+    await run(INSTALL, ["--scope", "api"], { cwd: s.dir });
+    const cfg = JSON.parse(s.read(".claude/settings.local.json"));
+    assert(cfg.hooks.Stop.length === 1, "expected 1 Stop entry, got " + cfg.hooks.Stop.length);
+    assertHas(cfg.hooks.Stop[0].hooks[0].command, "--scope api", "hook command");
+  } finally { s.cleanup(); }
+});
+
+test("install: changing the scope replaces the entry instead of stacking", async () => {
+  const s = sandbox();
+  try {
+    await run(INSTALL, ["--scope", "api"], { cwd: s.dir });
+    await run(INSTALL, ["--scope", "web"], { cwd: s.dir });
+    const cfg = JSON.parse(s.read(".claude/settings.local.json"));
+    assert(cfg.hooks.Stop.length === 1, "expected 1 Stop entry, got " + cfg.hooks.Stop.length);
+    assertHas(cfg.hooks.Stop[0].hooks[0].command, "--scope web", "hook command");
+  } finally { s.cleanup(); }
+});
+
+test("install: uninstall removes our entry and leaves others alone", async () => {
+  const s = sandbox();
+  try {
+    s.write(".claude/settings.local.json", JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "node other-tool.mjs" }] }] },
+    }, null, 2));
+    await run(INSTALL, ["--scope", "api"], { cwd: s.dir });
+    const r = await run(INSTALL, ["--uninstall"], { cwd: s.dir });
+    assertHas(r.out, "Removed unlazy Stop hook");
+    const cfg = JSON.parse(s.read(".claude/settings.local.json"));
+    assert(cfg.hooks.Stop.length === 1, "expected the unrelated hook to remain");
+    assertHas(cfg.hooks.Stop[0].hooks[0].command, "other-tool.mjs", "unrelated hook");
+  } finally { s.cleanup(); }
+});
+
+test("install: an upstream v2.0 entry is still recognised and removable", async () => {
+  const s = sandbox();
+  try {
+    s.write(".claude/settings.local.json", JSON.stringify({
+      hooks: {
+        Stop: [{
+          hooks: [{
+            type: "command",
+            command: 'node "/home/me/.claude/skills/unlazy/scripts/stop-hook.mjs"',
+          }],
+        }],
+      },
+    }, null, 2));
+    const r = await run(INSTALL, ["--uninstall"], { cwd: s.dir });
+    assertHas(r.out, "Removed unlazy Stop hook");
+    const cfg = JSON.parse(s.read(".claude/settings.local.json"));
+    assert(!cfg.hooks, "settings should be left clean, got " + JSON.stringify(cfg));
+  } finally { s.cleanup(); }
+});
+
+// ---------------------------------------------------------------- driver
+
+const selected = tests.filter(t => t.name.includes(filter));
+let passed = 0;
+const failures = [];
+
+for (const t of selected) {
+  try {
+    await t.fn();
+    passed++;
+    console.log("ok   " + t.name);
+  } catch (e) {
+    failures.push({ name: t.name, err: e });
+    console.log("FAIL " + t.name + "\n     " + String(e.message).split("\n").join("\n     "));
+  }
+}
+
+console.log("");
+console.log(passed + "/" + selected.length + " passed");
+process.exit(failures.length ? 1 : 0);

--- a/tests/self-check.mjs
+++ b/tests/self-check.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// self-check.mjs : structural checks on the skill's own scripts.
+//
+//   node tests/self-check.mjs
+//
+// Lives in a file rather than as an inline `node -e` in GATES.md on purpose: a
+// one-liner containing quotes, "^" or "!" is parsed differently by cmd.exe and
+// by sh, so an inline check can pass on one platform and report a phantom
+// failure on the other. A CHECK line should name a script, not embed one.
+//
+// Prints "self-check ok (N/N)" on success, which is what the gate matches.
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPTS = [
+  "scripts/gate-check.mjs",
+  "scripts/stop-hook.mjs",
+  "scripts/install-hooks.mjs",
+  "scripts/lib/gates.mjs",
+  "tests/run-tests.mjs",
+  "tests/self-check.mjs",
+];
+
+const read = (p) => readFileSync(join(ROOT, p), "utf8");
+const checks = [];
+const check = (name, fn) => checks.push({ name, fn });
+
+check("zero non-stdlib imports", () => {
+  const bad = [];
+  for (const p of SCRIPTS) {
+    for (const m of read(p).matchAll(/^\s*import\s[^;]*?from\s+["']([^"']+)["']/gm)) {
+      const spec = m[1];
+      if (!spec.startsWith("node:") && !spec.startsWith(".")) bad.push(p + " -> " + spec);
+    }
+  }
+  return bad.length ? "non-stdlib import: " + bad.join(", ") : null;
+});
+
+check("one shared gate parser", () => {
+  // The v2.0 checker and hook each had their own GATE_RE and disagreed about a
+  // gate's id when it carried no "Gn:" prefix. Parsing now lives only in the lib.
+  // This file names GATE_RE to describe the rule, so it scans only scripts/.
+  const owners = SCRIPTS.filter(p => p.startsWith("scripts/") && read(p).includes("GATE_RE"));
+  return owners.length === 1 && owners[0] === "scripts/lib/gates.mjs"
+    ? null
+    : "GATE_RE should exist only in scripts/lib/gates.mjs, found in: " + owners.join(", ");
+});
+
+check("no index-arithmetic argument filtering", () => {
+  // The v2.0 arg filter dropped index tIdx+1, which is 0 when --timeout is
+  // absent, silently discarding the first file argument.
+  return read("scripts/gate-check.mjs").includes("i !== tIdx + 1")
+    ? "gate-check.mjs still filters arguments by index arithmetic"
+    : null;
+});
+
+check("gate files are written atomically", () => {
+  const src = read("scripts/gate-check.mjs");
+  if (!src.includes("writeAtomic")) return "gate-check.mjs does not write via writeAtomic";
+  if (!src.includes("withFileLock")) return "gate-check.mjs does not take a lock before writing";
+  return null;
+});
+
+check("the hook resolves a scope rather than globbing the tree", () => {
+  const src = read("scripts/stop-hook.mjs");
+  if (!src.includes("resolveTarget")) return "stop-hook.mjs does not resolve a scope";
+  if (!src.includes("hookStatePath")) return "stop-hook.mjs does not use a per-scope state path";
+  return null;
+});
+
+check("every reference doc the skill links to exists", () => {
+  const skill = read("SKILL.md");
+  const missing = [];
+  for (const m of skill.matchAll(/\]\((references\/[^)]+|templates\/[^)]+|scripts\/[^)]+)\)/g)) {
+    try { read(m[1]); } catch { missing.push(m[1]); }
+  }
+  return missing.length ? "SKILL.md links to missing files: " + missing.join(", ") : null;
+});
+
+let passed = 0;
+const failures = [];
+for (const c of checks) {
+  let problem;
+  try { problem = c.fn(); } catch (e) { problem = e.message; }
+  if (problem) { failures.push(c.name + ": " + problem); console.log("FAIL " + c.name + "\n     " + problem); }
+  else { passed++; console.log("ok   " + c.name); }
+}
+
+console.log("");
+if (failures.length) {
+  console.log("self-check FAILED (" + passed + "/" + checks.length + ")");
+  process.exit(1);
+}
+console.log("self-check ok (" + passed + "/" + checks.length + ")");


### PR DESCRIPTION
**Rebased onto #3 and #8.** They are the first three commits on this branch (#8 is two), so the only commit that needs review here is the last one, `983dc01`. Merge either of those PRs and this diff shrinks on its own.

Earlier history, since it matters for reading the commits: I opened this without checking the existing PRs first, which was the wrong order, and it carried four things already filed by other people. My duplicates are closed (#11 in favour of #3, #12 in favour of #8), and the two features overlapping #5 are removed from this branch entirely.

| Already filed by someone else | Where it belongs now |
|---|---|
| gate-check drops its first file argument | #3, cherry-picked into this branch (also #7; my #11 closed) |
| install-hooks cannot recognise its own hook | #8, cherry-picked into this branch; my #12 closed |
| `--jobs`, concurrent execution of a leaf's checks | #5, with a sliding-window limiter. **Removed from this PR.** |
| Leaf dispatch order and readiness | #5's rolling dispatch, which beats the lockstep `--waves` I had. **Removed from this PR.** |
| A self-test suite | #2 ships `scripts/verify.mjs` |

### What the rebase changed in my own commit

Adopting #8 properly meant dropping my competing version, not just sitting on top of it. **My path-matching `isOurs` is gone**; #8's argv marker is now the mechanism, since it does not depend on the install path at all. On top of it I add only `--scope`, plus one tightening: the idempotence test goes from `isCurrent` alone to `isCurrent` **and** an exact command match, so re-pinning the hook to a different pipeline replaces the entry instead of reporting "already installed" while it guards the wrong one. I verified #8's moved-install replacement still behaves as its own commit describes, and that an unrelated Stop hook survives both paths. I also corrected #8's note that the hook ignores argv, which stopped being true once the hook reads `--scope`; the `--unlazy` tag is still ignored, as intended.

**#3's one-line guard is replaced rather than kept**, because scoping needs valued options (`--scope`, `--leaf`, `--timeout`) the index filter cannot express. The bug stays fixed either way, and #3 remains the standalone fix that should be judged on its own merits.

## What this PR is now

Running leaves at the same time is only safe if two things hold: no two of them write the same file, and the ledger survives being written from more than one place. #5 makes concurrent dispatch the default. This PR is the layer underneath it that makes that safe.

**1. Gate discovery globbed the whole working directory.** Any run touched every gates file present, so a leaf checking itself also ran and rewrote its siblings:

```
$ node gate-check.mjs gates/leaf-a.md
  PASS G1: A done
  PASS G1: B done          # never asked for
```

That is a leaf certifying a sibling it has never read, which defeats layer 2 of the verification hierarchy. A pipeline is now a scope under `.unlazy/<scope>/` with its own gates, status log, loop-guard counter and session binding, and discovery never crosses a scope boundary. When several scopes exist and none resolves, the tools refuse instead of guessing:

```
$ node gate-check.mjs
gate-check: 2 pipelines present (api, web); pass --scope <id> or set UNLAZY_SCOPE.
Refusing to run every pipeline's checks at once.
```

**2. The Stop hook blocked on gates the session does not own.** With pipeline `api` fully met and an untouched `web` present, ending the `api` session gave:

```
{"decision":"block","reason":"unlazy: 1 gate(s) unmet: G1..."}
```

Three problems at once: a finished session blocked by unrelated work, a gate named `G1` when that id is only unique within a file, and one `.unlazy-hook-state.json` counter hashed over every gate file, so pipelines reset and exhaust each other's `MAX_BLOCKS` guard. The hook now resolves one scope, counts per scope, reports `leaf-7:G3`, and allows the stop when it cannot tell whose pipeline it is looking at. Blocking blindly is worse than not blocking.

**3. Gate writes erased concurrent edits.** The write-back used a whole-file snapshot taken before the checks ran, so a gate hand-edited while checks were in flight was reverted. Writes now re-read under a lock, apply only the gates that run resolved, and replace the file by atomic rename. This one matters directly for #5: it makes concurrency the default while this write path was still snapshot-based.

**4. `OWNS:` makes file ownership checkable.** `PLAN.md` has always said no two leaves may own the same file, and #5's rolling dispatch relies on exactly that ("the contract in PLAN.md guarantees disjoint file ownership"). This turns it from a promise into a lease:

```markdown
OWNS: src/api/**, tests/api/*.test.ts
```

```
$ node gate-check.mjs --scope api --leaf leaf-1 --claim
CONFLICT src/shared/util.ts overlaps src/shared/** held by web/leaf-1
CLAIM REFUSED (1 conflict(s))          <- exit 3
```

Checked against every leaf in every scope, so the guarantee #5 assumes becomes one the tooling enforces.

**5. One parser.** `gate-check` fell back to `line<N>` for a gate with no `Gn:` prefix while `stop-hook` used the title's first 24 characters, so one gate had two ids and could not be reliably abandoned. Per ground rule 2, parsing, scope resolution, locking and leases now live in `scripts/lib/gates.mjs`, imported by both, with the spec and all three templates updated here. A self-check asserts `GATE_RE` exists in exactly one file.

Smaller: `CWD:` for a check belonging in a subproject, `--log` for an append-only per-scope status log so `PLAN.md` is never read-modify-written, `--bind`, `--list-scopes`.

## Deliberately not here

Scheduling. How many leaves run at once, in what order, and whether one leaf's own checks overlap all belong to the dispatcher, and #5 already does it better than the fixed batching I had. `--jobs`, `EXCLUSIVE:`, `NEEDS:` and `--waves` are gone from this branch, along with their tests, which is why it is about 190 lines smaller than when I opened it.

## Verification

**Verified.** `node tests/run-tests.mjs` gives `26/26 passed`; `node tests/self-check.mjs` gives `self-check ok (6/6)`. Zero dependencies, stdlib only. The suite asserts behaviour, not implementation: scope isolation (one pipeline's run provably leaves the other's files untouched), refusal on ambiguity, concurrent-edit survival, lease conflict and release, per-scope hook counters, the hook not blocking on a pipeline it does not own, the session binding, `CWD:`, the legacy layout, and hook install and uninstall idempotency. Two of those caught real bugs in my own work before I pushed it.

I also walked the manual matrix from CONTRIBUTING by hand: a ledger with a passing check, a failing check, a regex `EXPECT`, a manual gate and an `ABANDON` line, plus the hook's block, release-after-6, progress-reset and no-gates paths, and the installer's install, idempotence and uninstall round trip.

Because the rebase changed how the installer identifies its entries, I re-ran that part against the combined mechanism, from a directory not named `unlazy`: install pinned to a scope (one entry), install again (idempotent, one entry), re-pin to a different scope (replaced, still one entry, new command), the installed command actually executed as a hook (blocks with `unlazy [scope api]: 1 gate(s) unmet: leaf-1:G1` when pinned to the pipeline that has unmet gates, silent when pinned to the one that does not), uninstall leaving no `hooks` key, and #8's own case of an entry left by a moved install being replaced while an unrelated Stop hook survives.

**Reasoned, not verified.** Node 26.3.0 on Windows 11, with both bash and cmd.exe as the CHECK shell. Not re-run on Node 16 or on Linux or macOS. I kept the stated Node 16+ floor because the code uses no API newer than that, but that is from reading, not from running.

**Known limitation, documented.** Lease overlap is decided on each glob's literal prefix, so `src/a/**` and `src/b/**` are disjoint while `src/shared/**` and `src/shared/util.ts` are not. It can report a conflict a full glob intersection would clear, never the reverse, which is the safe direction for a tool whose job is stopping two leaves from writing one file.

## One note

No root `GATES.md` here, even though the skill dogfooding itself is appealing: the legacy layout auto-discovers `GATES.md` in the working directory, so shipping one would block every contributor with the Stop hook installed until they filled in its manual gates.

And one thing worth folding into the docs beyond this diff. My first attempt at a structural gate used an inline one-liner CHECK containing a character class. It passed under bash and failed under cmd.exe, which treats the caret as its escape character and does not accept a backslash-escaped quote, so the quoting state flipped mid-argument and the regex quietly changed meaning. Same class of problem as the missing `#` noted in #8. A gate that passes on one shell and phantom-fails on another is worse than no gate, so `references/gates.md` now says a CHECK line should name a script rather than embed one.
