### PR TITLE
fix(gate-check): stop dropping the first file argument

### DIFF
--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -20,7 +20,10 @@ const statusOnly = args.includes("--status");
 let timeoutSec = 120;
 const tIdx = args.indexOf("--timeout");
 if (tIdx !== -1) timeoutSec = Number(args[tIdx + 1]) || 120;
-const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
+// Skip the value after --timeout, but only when --timeout is actually present:
+// indexOf returns -1 when it is absent, and dropping index -1 + 1 = 0 silently
+// discarded the first file argument.
+const fileArgs = args.filter((a, i) => !a.startsWith("--") && !(tIdx !== -1 && i === tIdx + 1));
 
 function defaultFiles(dir) {
   const found = [];


### PR DESCRIPTION
One line, and it produces a false `ALL MET`.

```js
const tIdx = args.indexOf("--timeout");
const fileArgs = args.filter((a, i) => !a.startsWith("--") && i !== tIdx + 1);
```

`indexOf` returns `-1` when `--timeout` is absent, so `tIdx + 1` is `0` and index 0 is excluded on every run without a timeout. The first file argument is silently discarded.

## Reproduction, on current main

Two gate files, each with a check that passes:

```
$ node gate-check.mjs gates/leaf-a.md gates/leaf-b.md
  PASS G1: B done
gates/leaf-b.md: 1 gates
ALL MET (1 met)

$ grep '^- \[' gates/leaf-a.md
- [ ] G1: A done
```

`leaf-a.md` was never opened, and the run reported success anyway.

Naming a single file is worse, because `fileArgs` comes out empty and discovery takes over: the run silently widens to every gates file in the directory instead of the one asked for. That is the shape of the documented per-leaf call in `references/orchestration.md`, so in orchestrated mode a leaf verifying itself also executes and rewrites its siblings' gates.

The bug hides behind `--timeout`: pass it and the arithmetic is accidentally correct, which is presumably why it survived.

## The fix

Apply the guard only when the flag is actually present:

```js
const fileArgs = args.filter((a, i) => !a.startsWith("--") && !(tIdx !== -1 && i === tIdx + 1));
```

Four lines including the comment. No behaviour change to any invocation that already worked.

## Verified

Exercised by hand per CONTRIBUTING, one ledger containing a passing check, a failing check, a regex `EXPECT`, a manual gate and an `ABANDON` line:

```
  PASS G1: passing check
  FAIL G2: failing check
       nope
  PASS G3: regex EXPECT
GATES.md: 5 gates
UNMET: 2 (met: 2, abandoned: 1)
```

G1 and G3 flipped with evidence recorded, G2 stayed unmet, G4 stayed unmet as a manual gate, G5 counted as abandoned. Then `--status` (reports without running), `--timeout 30 GATES.md` (still consumes its value, still finds the file), and argument-free discovery: all three agree on `UNMET: 2 (met: 2, abandoned: 1)`.

Tested on Node 26.3.0, Windows 11, with both bash and cmd.exe as the check shell. Not re-run on Node 16 or on Linux or macOS, though nothing here touches platform-specific behaviour.

Found while working on #10, which contains this fix as part of a larger argument parser. This PR is the standalone version so it can land on its own; #10 will conflict here and I will rebase it onto whatever you merge.
