### PR TITLE
fix(install-hooks): recognise our own hook when the skill is not in a dir named unlazy

### DIFF
--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -40,10 +40,17 @@ if (existsSync(target)) {
 settings.hooks = settings.hooks || {};
 const stopHooks = Array.isArray(settings.hooks.Stop) ? settings.hooks.Stop : [];
 
+// Identify our entries by this script's own sibling hook path first. Matching on
+// the literal word "unlazy" only works while the skill sits under a directory of
+// that name: vendor it, rename it, or install it anywhere else and the installer
+// stops recognising its own entries, so every install stacks another hook and
+// uninstall reports nothing to remove. The word is still accepted so hooks
+// written from an "unlazy" directory stay removable from either install.
 const isOurs = (entry) =>
   Array.isArray(entry?.hooks) &&
   entry.hooks.some(h => typeof h?.command === "string" &&
-    h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER));
+    (h.command.includes(hookScript) ||
+      (h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER))));
 
 const kept = stopHooks.filter(e => !isOurs(e));
 


### PR DESCRIPTION
`isOurs` identifies the installer's own entries by looking for the literal string `unlazy` in the hook command, which in practice means in the skill's own installed path:

```js
const MARKER = "unlazy";
const isOurs = (entry) => ... h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER);
```

Install the skill anywhere whose path does not contain that word and the installer stops recognising hooks it wrote itself. Both idempotence and uninstall quietly stop working.

## Reproduction, on current main

Scripts copied into a directory not named `unlazy`, then installed three times:

```
$ node install-hooks.mjs   # x3, each reporting success
$ # Stop entries registered:
3
$ node install-hooks.mjs --uninstall
Nothing to remove: no unlazy Stop hook found in .../.claude/settings.local.json
$ # Stop entries remaining:
3
```

Every install stacks another Stop hook, and nothing can clean any of them up. The installer reports success each time, so there is no signal that anything is wrong until the user notices the same hook firing repeatedly.

This is reachable in ordinary use: cloning to a different directory name, vendoring the scripts into a project, or renaming an existing install. It is also the case a user cannot debug from the output, since the message says the install worked.

## The fix

Match this script's own sibling `stop-hook.mjs` path first, and keep accepting the `unlazy` spelling so entries written from an `unlazy`-named install stay removable:

```js
const isOurs = (entry) =>
  Array.isArray(entry?.hooks) &&
  entry.hooks.some(h => typeof h?.command === "string" &&
    (h.command.includes(hookScript) ||
      (h.command.includes("stop-hook.mjs") && h.command.toLowerCase().includes(MARKER))));
```

Eight lines including the comment, no new dependencies, no change to any install that already worked.

## Verified

Exercised by hand per CONTRIBUTING. From a directory not named `unlazy`:

- install, then two more installs: `Already installed ... (idempotent, nothing changed)`, 1 Stop entry
- uninstall: `Removed unlazy Stop hook from ...`, leaving no `hooks` key at all

Backward compatibility, seeded by hand with a v2.0-era entry whose command is `node /home/me/.claude/skills/unlazy/scripts/stop-hook.mjs` plus one unrelated Stop hook:

- uninstall from the differently-named install removed the v2.0 entry and left the unrelated hook untouched (`remaining: 1 -> node some-other-tool.mjs`)

The unchanged path, from an `unlazy`-named install: install, idempotence, uninstall, and the `--shared` target creating and cleaning `settings.json`.

Tested on Node 26.3.0, Windows 11. Not re-run on Node 16 or on Linux or macOS; the change is a string comparison, so I would not expect platform sensitivity beyond the path separators already handled by `join`.

Found while working on #10, which contains this fix. This PR is the standalone version so it can land on its own; #10 will conflict here and I will rebase it onto whatever you merge.
