### PR TITLE
docs: add COLM 2026 test-time scaling paper to the research list

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ So: models default to minimum effort, effort responds to structure, and structur
 
 Everything cited, newest first:
 
+- [Test-Time Scaling in Reasoning Models Is Not Effective for Knowledge-Intensive Tasks Yet](https://arxiv.org/abs/2509.06861) (COLM 2026): more test-time compute often raises hallucination rates, and compute-only scaling cannot add new information.
 - [Fortune: Advanced AI is showing signs of laziness](https://fortune.com/2026/07/28/advanced-ai-models-laziness-open-ai-anthropic/) (July 2026)
 - [When More Thinking Hurts: Overthinking in LLM Test-Time Compute Scaling](https://arxiv.org/abs/2604.10739) (April 2026)
 - [SlopCodeBench: How Coding Agents Degrade Over Long-Horizon Iterative Tasks](https://arxiv.org/abs/2603.24755) (March 2026)


### PR DESCRIPTION
Thanks for unlazy. I came across it today, watched the intro, read through the repo, then cloned it
and ran the gate checker against a scratch file to see it work. The evidence ledger is a good idea.
Small thing back: one paper for the research list.

On placement: the list says newest first, and although the arXiv ID reads 2509, v3 was last revised
6 Aug 2026, which is newer than the July 2026 entry, so I put it at the top. If you order that list
by ID instead, it belongs one below the April 2026 entry.

I went through the open PRs and didn't see this one already coming in. It's adjacent to the
overthinking entry but not the same argument: it gives a mechanism (hallucination rate tracks how
willing the model is to answer at all, and longer reasoning encourages more attempts) and a limit
(compute-only test-time scaling is post-processing over a fixed model, so it can't introduce new
information about the answer). Both are stated in the abstract. 14 reasoning models evaluated, code
and data at https://github.com/XuZhao0/tts-knowledge.

One format question, and it's your call: CONTRIBUTING asks for a one-line claim, but the existing
entries are title and year only. I went with a short claim, and I'm happy to cut it back to match
the rest of the list if you'd rather keep it uniform.
