### PR TITLE
docs(gates): three authoring rules for gates that cannot fail

### DIFF
--- a/references/gates.md
+++ b/references/gates.md
@@ -52,6 +52,19 @@ A gate is unmet if any of these hold:
   ask whether the outcome is observable at all; if it is not, sharpen it.
 - **Make EXPECT decisive.** Match the line that can only appear on success
   (`8/8 passed`), not one that appears either way (`done`).
+- **Give a negative gate a positive control.** A gate proving absence is usually
+  written `cmd && echo FOUND || echo NOT_FOUND`, whose passing token comes from the
+  failure branch: a missing file, a wrong path or a malformed pattern all report
+  absence. Before trusting one, run its CHECK against a case you know contains the
+  thing and confirm it fails. A gate that has never failed has not been tested.
+- **Never make a supplied number the EXPECT.** When a brief hands you a figure to
+  cross check, gate on measuring the figure, not on matching it. `EXPECT: 7` makes
+  agreement with the brief the definition of success, so a contradicting measurement
+  of your own reads as your failure and invites you to bend it.
+- **Look at which gates ended up manual.** Checkability and risk are anti correlated:
+  the outcomes hardest to prove by command are usually the ones most likely to be
+  silently wrong. If one gate is manual, check whether it is also the riskiest outcome
+  in the leaf, and try harder to make that one runnable.
 - **Cap evidence.** gate-check records the deciding tail of output. When
   filling manual evidence by hand, quote the deciding lines or cite
   `file:line`, never paste a log.


### PR DESCRIPTION
Three bullets added to the "Writing good gates" section of `references/gates.md`. Docs only: no format, script or template changes, so the gate file contract is untouched.

### Where these came from

I trialled the skill on a real task rather than on fixtures: a 16 week Canvas course readiness audit, gates authored by GLM 5.2 running under opencode, following SKILL.md with no hook installed. The model followed the skill correctly and still wrote a gate that could not fail, and it happened to be the gate guarding the task's one hard safety constraint (read only, no writes). Details and the exact gate are in a comment on #13.

These are the authoring side of that. #13 covers the tool side, and I did not want to duplicate it.

### The three rules

1. **Give a negative gate a positive control.** The idiomatic shell assertion of absence is `cmd && echo FOUND || echo NOT_FOUND`, whose passing token is produced by the failure branch. A missing file, a wrong path or a malformed pattern all report absence, so the gate passes having inspected nothing. Absence gates are the ones you most want to be true, which is when a false green costs most. `EXPECT: decisive` already warns against tokens that appear on both paths, but this shape is not sloppiness: it is what a careful person reaches for when asked to prove a thing is not there.

2. **Never make a supplied number the EXPECT.** My brief handed the model figures to cross check against and asked for disagreement to be reported. It encoded one as `EXPECT: 7`. That makes agreement with the brief the definition of success, so the model's own contradicting measurement would have read as its failure. The Numbers rule says to measure any number you will report; this is its converse, that a number you were given is not evidence.

3. **Look at which gates ended up manual.** Of 17 gates the model wrote, 16 were runnable and 1 was manual. The manual one was pagination, which was the single largest correctness risk in the task and flagged as such in the brief. Checkability and risk appear anti correlated, so a high runnable ratio can still leave the most dangerous outcome ungated.

### Checked against CONTRIBUTING

- Wording tells the model what to do, not what to feel; each bullet ends in an action.
- Claims come from a reproducible run, not folklore.
- No em dashes or en dashes.
- Enforcement stays structural: rule 1 asks for more proof, not more promising.
- Zero dependency and format contract untouched.

Happy to cut this to rule 1 alone if you would rather keep the spec lean, or to fold it into #13 if you prefer it there.