### PR TITLE
feat: lint ledgers for oracles that cannot fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This section describes the current source tree. It does not claim that `2.1.0` has a Git tag or GitHub Release.
 
+### Gate authoring
+
+- Add `scripts/gate-lint.mjs`, a non-executing audit of ledger quality. Report as errors the oracles that cannot fail: a command whose output is fixed by its own text, and an expectation that appears verbatim inside the command meant to prove it. Report as warnings an expectation drawn from failure vocabulary, a slash wrapped literal path read as a regular expression, a title that names an activity rather than an outcome, an unmeasured number, and a ledger outside the documented size band. Reuse the shared parser, add `--strict` and `--json`, and emit `LINT OK` so a ledger can require its own quality as a gate.
+
 ### Correctness and fail-closed behavior
 
 - Replace positional-argument index arithmetic with a validating CLI parser. An explicitly named ledger is the only ledger targeted, regardless of option order.

--- a/SKILL.md
+++ b/SKILL.md
@@ -66,6 +66,13 @@ Remember that the checker proves only the declared command oracle. It cannot inf
 - Review consequential manual gates with evidence proportional to risk. Try to make the riskiest outcome runnable, but do not claim that manual status and risk generally correlate.
 - Prefer portable Node scripts. Do not assume `grep`, `tail`, or `tr` exists on stock Windows.
 - Re-run with the same declared shell and required toolchain. Treat an environment mismatch as a failed verification, not as evidence.
+- Lint the ledger before working it, so an oracle that cannot fail is caught at authoring time rather than certified at report time:
+
+```
+node <skill-dir>/scripts/gate-lint.mjs GATES.md
+```
+
+Fix every error it reports. Treat each warning as a prompt to sharpen the gate. Details in [references/gates.md](references/gates.md).
 
 ## Audit the final report
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Regression tests for the unlazy skill's zero-dependency enforcement tools",
   "type": "module",
   "scripts": {
-    "test": "node tests/run-tests.mjs && node tests/hardening-tests.mjs && node tests/stress-tests.mjs && node tests/self-check.mjs"
+    "test": "node tests/run-tests.mjs && node tests/hardening-tests.mjs && node tests/stress-tests.mjs && node tests/lint-tests.mjs && node tests/self-check.mjs"
   },
   "engines": {
     "node": ">=16"

--- a/references/gates.md
+++ b/references/gates.md
@@ -99,6 +99,28 @@ The checker validates a declared oracle. It cannot infer whether unrestricted En
 - **Review consequential manual gates by risk.** A contributor's single 17-gate course audit found that its only manual gate was also its most consequential. Use that observation as a prompt for stronger review, not as evidence of a general correlation between checkability and risk. Cite exact evidence and obtain a second review when the consequence warrants it.
 - **Keep evidence decisive.** Record the smallest output that proves the outcome. Do not paste full logs into a ledger.
 
+### Lint the ledger before working it
+
+The rules above are prose, and prose is the layer this project already treats as weakest. `gate-lint.mjs` makes the mechanical subset of them checkable. It never executes a `CHECK:`; it reads the ledger and judges its oracles.
+
+```text
+node scripts/gate-lint.mjs GATES.md
+node scripts/gate-lint.mjs --strict --json .unlazy/<scope>/gates/leaf-1.1.1.md
+```
+
+Errors are oracles that cannot fail: a command whose output is fixed by its own text, and an expectation that appears verbatim inside the command that is supposed to prove it. Warnings are weaker signals: an expectation drawn from vocabulary that failure output also uses, a slash wrapped literal path silently read as a regular expression, a title that names an activity rather than an outcome, a number that nothing measures, and a ledger outside the five to twelve band.
+
+Exit `0` is clean, `1` reports findings, `2` means the shared parser rejected the ledger. `--strict` promotes warnings to failures. A lint finding is a prompt to sharpen the gate, not proof that the outcome is wrong.
+
+Make a ledger require its own quality by linting as a gate:
+
+```markdown
+- [ ] G0: this ledger states outcomes that can fail
+  CHECK: node scripts/gate-lint.mjs GATES.md
+  EXPECT: LINT OK
+  EVIDENCE: pending
+```
+
 ## Abandonment
 
 Use abandonment only when a required outcome is genuinely impossible within the authorized task. Keep the original gate, add one non-empty reason, and name the abandonment in the final report. An abandonment is a visible handoff, not a passing check. If an entire requested deliverable is abandoned, do not describe the task as fully complete.

--- a/scripts/gate-lint.mjs
+++ b/scripts/gate-lint.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// gate-lint.mjs : audit whether a ledger is worth passing.
+// Zero dependencies. Node 16+.
+//
+// The checker and the Stop hook decide whether gates were met. Neither asks
+// whether the gates were worth meeting. A gate reading "the entire feature
+// works perfectly" with `CHECK: echo ok` and `EXPECT: ok` passes the checker,
+// the parent re-verification and the hook, because the oracle is real, runs,
+// and returns what it promised. Authoring is the one step in the enforcement
+// hierarchy that is still pure prose discipline, and this lints it.
+//
+// This never executes a CHECK. It reads the ledger and judges its oracles.
+//
+//   node gate-lint.mjs [options] <ledger.md ...>
+//     --strict   treat warnings as failures
+//     --json     machine-readable findings
+//
+// exit codes: 0 clean, 1 findings, 2 usage or parse error.
+//
+// Usable as a gate, so a ledger can require its own quality:
+//   CHECK: node scripts/gate-lint.mjs GATES.md
+//   EXPECT: LINT OK
+
+import { readFileSync } from "node:fs";
+import { parseGates } from "./lib/gates.mjs";
+
+const HELP = `usage: gate-lint.mjs [--strict] [--json] <ledger.md ...>
+
+Audit gate quality, not gate completion. Report oracles that cannot fail,
+expectations satisfied by their own command, titles that name an activity
+instead of an outcome, and ledgers outside the size band in
+references/gates.md. Never executes a CHECK.
+
+exit codes: 0 clean, 1 findings, 2 usage or parse error.`;
+
+const KNOWN_OPTIONS = new Set(["--strict", "--json", "--help", "-h"]);
+
+const args = process.argv.slice(2);
+if (!args.length) {
+  console.error(HELP);
+  process.exit(2);
+}
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(HELP);
+  process.exit(0);
+}
+for (const arg of args) {
+  if (arg.startsWith("--") && !KNOWN_OPTIONS.has(arg)) {
+    console.error("gate-lint: unknown option " + arg);
+    console.error("run gate-lint.mjs --help for usage");
+    process.exit(2);
+  }
+}
+const strict = args.includes("--strict");
+const asJson = args.includes("--json");
+const files = args.filter((a) => !a.startsWith("-"));
+if (!files.length) {
+  console.error("gate-lint: name at least one ledger file");
+  process.exit(2);
+}
+
+// An oracle whose output is fixed by its own text observes nothing.
+const SELF_DETERMINING = /^\s*(echo|printf|true|:|exit\s+0)\b/;
+// Tokens that appear in failure output as readily as in success output.
+const WEAK_EXPECT = new Set([
+  "ok", "okay", "done", "pass", "passed", "success", "successful", "succeeded",
+  "complete", "completed", "finished", "yes", "true", "0", "good", "fine", "working",
+]);
+// Openings that name an activity rather than an outcome a stranger could judge.
+const ACTIVITY_START = /^(work(ing)? on|improve|enhance|handle|support|ensure|make sure|try|attempt|look (at|into)|investigate|consider|review|refactor|clean ?up|polish|update|tidy|address|deal with|add support)\b/i;
+// A slash wrapped EXPECT is read as a regular expression. That is correct for
+// a pattern and wrong for a literal path, whose dots then match any character.
+// An unescaped inner slash is the tell: patterns rarely carry one, paths do.
+const PATH_LIKE = /[^\\]\//;
+
+const findings = [];
+const add = (file, level, gate, rule, message) =>
+  findings.push({ file, level, gate: gate || null, rule, message });
+
+let parseFailed = false;
+
+for (const file of files) {
+  let text;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch (error) {
+    console.error("gate-lint: cannot read " + file + ": " + error.message);
+    process.exit(2);
+  }
+
+  const doc = parseGates(text);
+  if (doc.errors.length) {
+    // A ledger the shared parser rejects cannot be judged on quality.
+    parseFailed = true;
+    for (const error of doc.errors) add(file, "error", null, "parse", error);
+    continue;
+  }
+
+  const live = doc.gates.filter((gate) => !doc.abandoned.has(gate.id));
+  const runnable = live.filter((gate) => gate.check);
+
+  for (const gate of live) {
+    const { id, title, check, expect } = gate;
+
+    if (check && SELF_DETERMINING.test(check)) {
+      add(file, "error", id, "tautological-check",
+        'CHECK cannot fail: "' + check + '" produces its output regardless of the system');
+    }
+
+    // "CHECK: node build.mjs --banner DONE" with "EXPECT: DONE" passes because
+    // the command prints the expectation, not because the outcome holds.
+    if (check && expect) {
+      const literal = gate.expectation && gate.expectation.kind === "text"
+        ? expect
+        : gate.expectation && gate.expectation.source;
+      if (literal && literal.length >= 2 && check.includes(literal)) {
+        add(file, "error", id, "expect-echoes-check",
+          'EXPECT "' + literal + '" appears verbatim in its own CHECK, so the command guarantees its own pass');
+      }
+    }
+
+    if (expect && WEAK_EXPECT.has(expect.trim().toLowerCase())) {
+      add(file, "warn", id, "weak-expect",
+        'EXPECT "' + expect + '" also appears in failure output; match a line only success can print');
+    }
+
+    if (gate.expectation && gate.expectation.kind === "regex" && PATH_LIKE.test(gate.expectation.source)) {
+      add(file, "warn", id, "path-read-as-regex",
+        'EXPECT "' + expect + '" looks like a literal path but is read as a regular expression, so its dots are wildcards');
+    }
+
+    if (!check) {
+      add(file, "warn", id, "manual-gate",
+        "no CHECK, so this outcome is judged by hand and its evidence is only as good as the reader");
+      if (/\d/.test(title)) {
+        add(file, "warn", id, "unmeasured-number",
+          'title states a number that nothing measures: "' + title + '"');
+      }
+    }
+
+    if (ACTIVITY_START.test(title)) {
+      add(file, "warn", id, "activity-not-outcome",
+        'names an activity, not an outcome a stranger could judge: "' + title + '"');
+    }
+  }
+
+  // references/gates.md: five to twelve gates per leaf is the useful range.
+  if (live.length && live.length < 5) {
+    add(file, "warn", null, "thin-ledger",
+      live.length + " live gates, under five, which usually means the leaf is under-specified");
+  }
+  if (live.length > 12) {
+    add(file, "warn", null, "fat-ledger",
+      live.length + " live gates, over twelve, which usually means this should have been two leaves");
+  }
+  if (live.length && runnable.length / live.length < 0.5) {
+    add(file, "warn", null, "mostly-manual",
+      runnable.length + "/" + live.length + " gates are runnable; a mostly manual ledger is prose with checkboxes");
+  }
+}
+
+const errors = findings.filter((f) => f.level === "error");
+const warnings = findings.filter((f) => f.level === "warn");
+const failed = errors.length > 0 || (strict && warnings.length > 0);
+
+if (asJson) {
+  console.log(JSON.stringify({
+    ok: !failed,
+    errors: errors.length,
+    warnings: warnings.length,
+    findings,
+  }, null, 2));
+} else {
+  let lastFile = null;
+  for (const finding of findings) {
+    if (finding.file !== lastFile) {
+      console.log(finding.file);
+      lastFile = finding.file;
+    }
+    const label = finding.level === "error" ? "ERROR" : "WARN ";
+    const who = finding.gate ? finding.gate + ": " : "";
+    console.log("  " + label + " " + who + finding.message + "  [" + finding.rule + "]");
+  }
+  console.log(findings.length
+    ? "LINT FINDINGS: " + errors.length + " error(s), " + warnings.length + " warning(s)"
+    : "LINT OK");
+}
+
+process.exit(parseFailed ? 2 : failed ? 1 : 0);

--- a/tests/lint-tests.mjs
+++ b/tests/lint-tests.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// lint-tests.mjs : behavioural tests for scripts/gate-lint.mjs.
+// Zero dependencies, cross-platform.
+//
+//   node tests/lint-tests.mjs            run all
+//   node tests/lint-tests.mjs regex      run tests whose name contains "regex"
+//
+// Prints "N/N passed" on success, which is the string CI matches on.
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LINT = join(HERE, "..", "scripts", "gate-lint.mjs");
+const filter = process.argv[2] || "";
+const DIR = mkdtempSync(join(tmpdir(), "unlazy-lint-test-"));
+
+const tests = [];
+const test = (name, fn) => tests.push({ name, fn });
+
+function write(name, body) {
+  const path = join(DIR, name);
+  writeFileSync(path, body);
+  return path;
+}
+
+function lint(...args) {
+  const result = spawnSync(process.execPath, [LINT, ...args], { encoding: "utf8" });
+  return { out: result.stdout + result.stderr, code: result.status };
+}
+
+// ------------------------------------------------------------- fixtures
+
+// Every defect below passes gate-check and the Stop hook today.
+const WEAK = write("weak.md", `# Gates: weak ledger
+
+Scope: a ledger that satisfies every enforcement layer and proves nothing
+
+- [ ] G1: the entire feature works perfectly
+  CHECK: echo ok
+  EXPECT: ok
+  EVIDENCE: pending
+
+- [ ] G2: improve the error handling
+  CHECK: node scripts/verify.mjs --banner DONE
+  EXPECT: DONE
+  EVIDENCE: pending
+
+- [ ] G3: renders 34 stat rows
+  EVIDENCE: pending
+
+- [ ] G4: config path is reported
+  CHECK: node scripts/show-path.mjs
+  EXPECT: /etc/app/conf/
+  EVIDENCE: pending
+`);
+
+const SOUND_BODY = `# Gates: sound ledger
+
+Scope: pricing section renders and behaves
+
+- [ ] G1: three tiers render with real copy
+  CHECK: node scripts/check.mjs pricing --tiers
+  EXPECT: 3/3 tiers rendered
+  EVIDENCE: pending
+
+- [ ] G2: annual toggle changes price and label
+  CHECK: node scripts/check.mjs pricing --toggle
+  EXPECT: toggle switched both fields
+  EVIDENCE: pending
+
+- [ ] G3: typecheck is clean
+  CHECK: npx tsc --noEmit
+  EXPECT: /Found 0 errors/
+  EVIDENCE: pending
+
+- [ ] G4: unit suite green
+  CHECK: node --test test/pricing.test.mjs
+  EXPECT: /# fail 0/
+  EVIDENCE: pending
+
+- [ ] G5: no console errors on load
+  CHECK: node scripts/check.mjs pricing --console
+  EXPECT: 0 console errors
+  EVIDENCE: pending
+`;
+
+const SOUND = write("sound.md", SOUND_BODY);
+const MANUAL = write("manual.md", SOUND_BODY + `
+- [ ] G6: copy reads as written by the brand, not by a model
+  EVIDENCE: pending
+`);
+
+// ------------------------------------------------------------- tests
+
+test("lint: an oracle that cannot fail is an error", () => {
+  const { out, code } = lint(WEAK);
+  assert.match(out, /G1: CHECK cannot fail/);
+  assert.equal(code, 1);
+});
+
+test("lint: an expectation printed by its own command is an error", () => {
+  assert.match(lint(WEAK).out, /G2:.*appears verbatim in its own CHECK/);
+});
+
+test("lint: an expectation shared with failure output is warned", () => {
+  assert.match(lint(WEAK).out, /G1:.*also appears in failure output/);
+});
+
+test("lint: an activity title is warned", () => {
+  assert.match(lint(WEAK).out, /G2:.*names an activity, not an outcome/);
+});
+
+test("lint: an unmeasured number in a manual gate is warned", () => {
+  assert.match(lint(WEAK).out, /G3:.*states a number that nothing measures/);
+});
+
+test("lint: a literal path read as a regex is warned", () => {
+  assert.match(lint(WEAK).out, /G4:.*looks like a literal path/);
+});
+
+test("lint: a deliberate slash wrapped pattern is not warned", () => {
+  assert.doesNotMatch(lint(SOUND).out, /looks like a literal path/);
+});
+
+test("lint: a ledger under the size band is warned", () => {
+  assert.match(lint(WEAK).out, /under five/);
+});
+
+test("lint: a sound ledger is clean and exits 0", () => {
+  const { out, code } = lint(SOUND);
+  assert.match(out, /^LINT OK$/m);
+  assert.equal(code, 0);
+});
+
+test("lint: a manual gate warns without failing", () => {
+  const { out, code } = lint(MANUAL);
+  assert.match(out, /G6:.*judged by hand/);
+  assert.equal(code, 0);
+});
+
+test("lint: strict promotes warnings to failure", () => {
+  assert.equal(lint(MANUAL).code, 0);
+  assert.equal(lint("--strict", MANUAL).code, 1);
+});
+
+test("lint: json reports counts and stays parseable", () => {
+  const data = JSON.parse(lint("--json", WEAK).out);
+  assert.equal(data.ok, false);
+  assert.ok(data.errors >= 2, "expected at least two errors, got " + data.errors);
+  assert.ok(data.findings.every((f) => f.rule && f.level));
+});
+
+test("lint: a ledger the shared parser rejects exits 2, not 1", () => {
+  const broken = write("broken.md", "# Gates: broken\n\n- [ ] no explicit id here\n");
+  assert.equal(lint(broken).code, 2);
+});
+
+test("lint: multiple ledgers in one run are all honored", () => {
+  const { out } = lint(SOUND, WEAK);
+  assert.match(out, /weak\.md/);
+  assert.match(out, /G1: CHECK cannot fail/);
+});
+
+test("lint: an unknown option exits 2", () => {
+  assert.equal(lint("--nope", SOUND).code, 2);
+});
+
+test("lint: no arguments exits 2", () => {
+  assert.equal(lint().code, 2);
+});
+
+// ------------------------------------------------------------- runner
+
+const selected = tests.filter((t) => t.name.includes(filter));
+let passed = 0;
+const failures = [];
+
+for (const t of selected) {
+  try {
+    t.fn();
+    passed++;
+    console.log("ok   " + t.name);
+  } catch (e) {
+    failures.push(t.name);
+    console.log("FAIL " + t.name + "\n     " + String(e.message).split("\n").join("\n     "));
+  }
+}
+
+console.log("");
+console.log(passed + "/" + selected.length + " passed");
+try { rmSync(DIR, { recursive: true, force: true }); } catch { /* windows lag */ }
+process.exit(failures.length ? 1 : 0);

--- a/tests/self-check.mjs
+++ b/tests/self-check.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SCRIPTS = [
   "scripts/gate-check.mjs",
+  "scripts/gate-lint.mjs",
   "scripts/stop-hook.mjs",
   "scripts/install-hooks.mjs",
   "scripts/lib/gates.mjs",
@@ -24,6 +25,7 @@ const SCRIPTS = [
   "tests/run-tests.mjs",
   "tests/hardening-tests.mjs",
   "tests/stress-tests.mjs",
+  "tests/lint-tests.mjs",
   "tests/self-check.mjs",
 ];
 


### PR DESCRIPTION
## The failure

The checker and the Stop hook decide whether gates were **met**. Neither asks whether the gates were **worth meeting**.

`references/gates.md` already names this in prose:

> `G1: invoices reconcile` plus `CHECK: node -e "console.log('ok')"` is syntactically valid and semantically useless.

That ledger today:

```text
$ node scripts/gate-check.mjs --approve canon.md
  PASS G1: invoices reconcile
ALL MET (1 met)                       exit 0
```

The Stop hook allows the stop. Parent `--reverify` re-runs the oracle and it passes again, because the oracle is real, it runs, and it returns exactly what it promised. Every layer of the hierarchy is satisfied by a gate that observes nothing.

Gate authoring is the one step in the hierarchy still enforced by prose alone, and prose is the layer this project treats as weakest. The five authoring rules under "Author gates that can fail" are exactly the kind of instruction the README argues a model under-executes precisely when it is under pressure.

## The contract after the change

`scripts/gate-lint.mjs` audits a ledger without executing anything. It reads through `lib/gates.mjs`, so it cannot drift from the checker or the hook, which is the class of bug the shared parser was introduced to end.

**Errors**, the oracles that cannot fail:

| rule | catches |
| --- | --- |
| `tautological-check` | a command whose output is fixed by its own text (`echo`, `printf`, `true`, `:`, `exit 0`) |
| `expect-echoes-check` | `EXPECT:` appearing verbatim inside the `CHECK:` meant to prove it |

**Warnings**, weaker signals worth a second look:

| rule | catches |
| --- | --- |
| `weak-expect` | an expectation drawn from vocabulary failure output also uses (`ok`, `done`, `passed`) |
| `path-read-as-regex` | a slash wrapped literal path silently read as a regular expression, so its dots are wildcards |
| `activity-not-outcome` | a title naming an activity rather than an outcome a stranger could judge |
| `unmeasured-number` | a number in a title that nothing measures, per the numbers rule |
| `thin-ledger` / `fat-ledger` / `mostly-manual` | a ledger outside the documented five to twelve band, or mostly prose with checkboxes |

Exit `0` clean, `1` findings, `2` when the shared parser rejects the ledger. `--strict` promotes warnings to failures. `--json` for harness use. The final line is `LINT OK` or `LINT FINDINGS: N error(s), M warning(s)`, so a ledger can require its own quality:

```markdown
- [ ] G0: this ledger states outcomes that can fail
  CHECK: node scripts/gate-lint.mjs GATES.md
  EXPECT: LINT OK
  EVIDENCE: pending
```

A finding is a prompt to sharpen the gate, never a claim that the outcome is wrong. The lint is advisory by construction: it cannot flip a box, write evidence, or allow a stop.

## Regression evidence

`tests/lint-tests.mjs`, 16 tests, wired into `npm test` before `self-check`. Both new files are added to the `self-check` script list, so the zero-dependency and Node 16 floor checks cover them.

```text
$ npm test
26/26 passed          run-tests
19/19 passed          hardening-tests
10/10 passed          stress-tests
16/16 passed          lint-tests
self-check ok (9/9)
```

The doc's own canonical example, which is `ALL MET` today:

```text
$ node scripts/gate-lint.mjs canon.md
  ERROR G1: EXPECT "ok" appears verbatim in its own CHECK, so the command guarantees its own pass  [expect-echoes-check]
  WARN  G1: EXPECT "ok" also appears in failure output; match a line only success can print  [weak-expect]
LINT FINDINGS: 1 error(s), 2 warning(s)          exit 1
```

Tests cover each rule firing, and each rule **not** firing on a sound ledger. The false-positive guard matters most on `path-read-as-regex`: a first pass flagged any slash wrapped expectation without metacharacters, which wrongly caught deliberate patterns like `/Found 0 errors/`. The rule now keys on an unescaped inner slash, which distinguishes `/etc/app/conf/` from a real pattern, and `lint: a deliberate slash wrapped pattern is not warned` pins that.

Also covered: multi-file targeting, unknown options, no arguments, `--strict` promotion, `--json` shape, and exit `2` rather than `1` on a ledger the parser rejects.

## Notes against CONTRIBUTING

- Enforcement stays structural: a rule moves from prose in `references/gates.md` to a runnable check.
- No format change, so the parser, checker, hook and templates keep one contract. The lint is a reader, not a writer.
- The `CHECK:` trust boundary is untouched. The lint never executes a command, so it needs no approval and cannot be a new execution surface.
- Zero dependencies, Node 16 stdlib only, cross-platform (no shell invoked at all).
- No em dash or en dash in the patch.

## Not in scope

This catches mechanically weak gates. It cannot catch a well-formed ledger that quietly narrows the task, which needs a reviewer holding the original request. Worth saying plainly in the docs rather than implying the lint closes the gap.
