### PR TITLE
Enforce native parallel dispatch launch waves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This section describes the current source tree. It does not claim that `2.1.0` h
 - Describe scopes and leases as coordination rather than filesystem or process isolation.
 - Add opt-in `--jobs <N>` rolling check concurrency while retaining sequential default behavior and deterministic ledger-order reporting.
 - Add declared readiness states, real `node-*` branch paths, explicit dependencies, and rolling leaf dispatch to the plan and orchestration guide.
+- Add atomic native dispatch waves that require every independent leaf to receive a distinct host start handle before the first return is accepted.
+- Add Codex and Claude Code launch adapters, incomplete-wave Stop-hook enforcement, and a measured worker-overlap regression without adding a model subprocess runner.
 - Key Stop-hook progress state to the session and scope, serialize state changes, and retain unlazy's own six-block no-progress release.
 
 ### Installer, package, and documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,15 +31,15 @@ See [references/gates.md](references/gates.md) for the full shell and success co
 
 ## Scopes and leases are not a sandbox
 
-Scopes limit unlazy's gate discovery, log target, hook association, and lease labels. Ownership leases coordinate tools that voluntarily use the protocol. Neither mechanism prevents a process from reading or writing another path.
+Scopes limit unlazy's gate discovery, log target, hook association, dispatch waves, and lease labels. Ownership leases and dispatch launch barriers coordinate tools that voluntarily use the protocol. Neither mechanism prevents a process from reading or writing another path.
 
 Separate worktrees can reduce ordinary path contention, but they may still share external caches and services. Use operating-system, container, or virtual-machine isolation for untrusted code. See [references/parallel.md](references/parallel.md).
 
 ## Stop hook and local state
 
-The optional Claude Code Stop hook scans ledgers and writes progress state. It does not execute `CHECK:` commands. It emits Claude Code's documented top-level block decision while the resolved session pipeline has unmet gates and releases after unlazy's own six no-progress blocks.
+The optional Claude Code Stop hook scans ledgers and dispatch state, then writes progress state. It does not execute `CHECK:` commands or create agent sessions. It emits Claude Code's documented top-level block decision while the resolved session pipeline has unmet gates or incomplete dispatch waves and releases after unlazy's own six no-progress blocks.
 
-Runtime and binding files live under `.unlazy/` in scoped mode. Legacy mode may use `.unlazy-hook-state.json`. Keep both paths in the project's ignore rules. Session ids in bindings are routing values, not secrets or authentication tokens.
+Runtime, binding, and dispatch files live under `.unlazy/` in scoped mode. Legacy mode may use `.unlazy-hook-state.json`. Keep both paths in the project's ignore rules. Session ids in bindings and native agent ids in dispatch waves are routing values, not secrets or authentication tokens.
 
 ## Installer targets and privacy
 
@@ -55,7 +55,9 @@ Install and uninstall preserve unrelated hooks. The installer refuses malformed 
 
 ## Evidence and logs
 
-Command output can contain private paths or other sensitive text. Gate evidence is deliberately capped, but it is still written into the ledger. Design checks to emit a concise success marker and avoid printing secrets. Review ledgers and status logs before committing or sharing them.
+Command output can contain private paths or other sensitive text. Gate evidence is deliberately capped, but it is still written into the ledger. Dispatch state contains timestamps and opaque host handles. Never put prompts, credentials, or result bodies in a handle. Design checks to emit a concise success marker and avoid printing secrets. Review ledgers, dispatch state, and status logs before committing or sharing them.
+
+A sealed wave proves only that the host returned a distinct native start handle for every declared leaf before Unlazy accepted a return. It does not prove exact CPU overlap, worker honesty, filesystem isolation, successful gates, or correct integration.
 
 Unlazy does not intentionally collect telemetry or send approval, gate, or hook-state records to a service. A `CHECK:` command can perform its own network or logging activity because it is arbitrary code.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,20 +32,20 @@ Do not silently remove an impossible gate. Add `ABANDON: <id> <non-empty reason>
 ## Pick the smallest fitting mode
 
 - **Solo:** Use one `GATES.md` for a focused task that fits one working session.
-- **Orchestrated:** For a build or deep review, read [references/method.md](references/method.md) and [references/orchestration.md](references/orchestration.md). Write the contract and tree before fan-out. Give every leaf and branch its own gates file.
-- **Parallel:** Before dispatching concurrent leaves or pipelines, also read [references/parallel.md](references/parallel.md). Declare disjoint `OWNS:` paths and claim them. Treat scopes and leases as coordination, never as filesystem isolation or a security boundary.
+- **Orchestrated:** For a build or deep review, read [references/method.md](references/method.md), [references/orchestration.md](references/orchestration.md), and [references/dispatch.md](references/dispatch.md). Write the contract and tree before fan-out. Give every leaf and branch its own gates file.
+- **Parallel:** Before dispatching concurrent leaves or pipelines, also read [references/parallel.md](references/parallel.md). Declare disjoint `OWNS:` paths, claim them, and use a dispatch launch wave. Treat scopes, leases, and wave state as coordination, never as filesystem isolation or a security boundary.
 
-Keep check execution sequential by default. Use `--jobs <N>` only for independent runnable gates when deterministic parallel verification saves wall-clock time. Continue printing and recording results in gate order.
+Keep check execution sequential by default. Use `--jobs <N>` only for independent runnable gates when deterministic parallel verification saves wall-clock time. Continue printing and recording results in gate order. `--jobs` never creates agent sessions; native agent concurrency follows the dispatch contract.
 
 ## Build the Depth Tree
 
 1. Split at natural task boundaries. Use the requested depth only while each leaf remains a coherent deliverable.
 2. Give each leaf a narrow contract, exact file ownership, and its own ledger.
 3. Give each branch integration gates for child verification, interface compatibility, end-to-end behavior, and regressions.
-4. Dispatch only leaves whose declared dependencies are verified and whose ownership claim succeeded.
+4. Dispatch only leaves whose declared dependencies are verified and whose ownership claim succeeded. For each independent `READY` set, open a wave, launch every native agent, record every host handle, seal the wave, and only then wait for a result.
 5. Re-run each returned leaf's runnable gates with `--reverify`; do not mistake `--status` for re-execution.
 
-Use rolling dispatch: when a verified leaf unblocks another, dispatch the newly ready leaf without waiting for unrelated in-flight work. Keep states and dependencies in `PLAN.md`; append events to the scope status log.
+Use rolling dispatch: when a verified leaf unblocks another, open and launch the next ready wave without waiting for unrelated in-flight work. Keep states and dependencies in `PLAN.md`; keep dispatch state in `.unlazy/<scope>/dispatch.json`; append events to the scope status log.
 
 ## Work each leaf in four passes
 
@@ -79,7 +79,7 @@ Offer the hook once when structural stop enforcement would materially help. Neve
 node <skill-dir>/scripts/install-hooks.mjs
 ```
 
-The hook returns Claude Code's top-level `decision: "block"` response while this session's resolved pipeline has unmet gates. Its own session-keyed progress guard releases after six consecutive blocks without ledger progress. Remove it with `--uninstall`.
+The hook returns Claude Code's top-level `decision: "block"` response while this session's resolved pipeline has unmet gates or incomplete dispatch waves. Its own session-keyed progress guard releases after six consecutive blocks without pipeline progress. Remove it with `--uninstall`.
 
 Default installation writes machine-specific project-local settings. Keep `.claude/settings.local.json`, `.unlazy/`, and `.unlazy-hook-state.json` in the project's ignore rules. Shared installation contains absolute Node and hook-script paths and is usually not portable across machines. Read [SECURITY.md](SECURITY.md) before choosing an install target.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Regression tests for the unlazy skill's zero-dependency enforcement tools",
   "type": "module",
   "scripts": {
-    "test": "node tests/run-tests.mjs && node tests/hardening-tests.mjs && node tests/stress-tests.mjs && node tests/self-check.mjs"
+    "test": "node tests/run-tests.mjs && node tests/dispatch-tests.mjs && node tests/hardening-tests.mjs && node tests/stress-tests.mjs && node tests/self-check.mjs"
   },
   "engines": {
     "node": ">=16"

--- a/references/dispatch.md
+++ b/references/dispatch.md
@@ -1,0 +1,74 @@
+# Native agent dispatch
+
+Use this contract whenever orchestrated mode has two or more independent `READY` leaves. Unlazy records native launches; the host creates the agent sessions.
+
+For one wave, every native launch call and every `start` record must finish before the first wait, join, result read, or return record.
+
+## Open and seal a launch wave
+
+Claim every leaf first. Partition more `READY` leaves into later waves when they exceed the host's current concurrency limit. Then open one wave with the exact ids:
+
+```text
+node <skill-dir>/scripts/dispatch-check.mjs open --scope <scope> --wave ready-1 --leaf leaf-1.1.1 --leaf leaf-1.1.2
+```
+
+For each leaf, call the host's native nonblocking launch tool and record the opaque, nonsecret handle it returns:
+
+```text
+node <skill-dir>/scripts/dispatch-check.mjs start --scope <scope> --wave ready-1 --leaf leaf-1.1.1 --handle <host-agent-id-1>
+node <skill-dir>/scripts/dispatch-check.mjs start --scope <scope> --wave ready-1 --leaf leaf-1.1.2 --handle <host-agent-id-2>
+```
+
+Seal the wave before waiting for any result:
+
+```text
+node <skill-dir>/scripts/dispatch-check.mjs seal --scope <scope> --wave ready-1
+```
+
+Seal fails until every declared leaf has a distinct start handle. `return` fails before seal. These refusals catch the serial pattern where a driver launches one leaf, waits for it, and only then launches the next.
+
+When a native agent finishes, record the return before parent re-verification:
+
+```text
+node <skill-dir>/scripts/dispatch-check.mjs return --scope <scope> --wave ready-1 --leaf leaf-1.1.1
+```
+
+A return records scheduler completion, including a failed worker result. It does not mark the leaf `VERIFIED`; the parent still runs the leaf gates and reviews manual evidence.
+
+Check the finished wave with:
+
+```text
+node <skill-dir>/scripts/dispatch-check.mjs status --scope <scope> --wave ready-1
+```
+
+`status` exits `0` only after every declared leaf returned. Dispatch state and timestamps live in `.unlazy/<scope>/dispatch.json`; lifecycle events also append to the scope status log.
+
+## Codex adapter
+
+[Current Codex releases support parallel subagents](https://developers.openai.com/codex/agent-configuration/subagents). Use the native subagent tools available in the host. When the tools are named `spawn_agent` and `wait_agent`, follow this exact order:
+
+1. call `spawn_agent` once for each leaf in the open wave
+2. record each returned agent id with `dispatch-check start`
+3. seal the wave
+4. call `wait_agent` only after seal
+5. record each completion with `dispatch-check return`, then reverify it
+
+Do not use `codex exec` as a substitute. It creates a separate CLI process rather than a native subagent owned and visible through the current host.
+
+## Claude Code adapter
+
+[Claude Code background subagents run concurrently](https://code.claude.com/docs/en/sub-agents#run-subagents-in-foreground-or-background). Launch every leaf as a background `Agent` task, record every returned task or agent id, and seal before reading any result. Do not issue foreground Agent calls one after another.
+
+For a large regular fan-out, prefer a [Dynamic Workflow](https://code.claude.com/docs/en/workflows). Its `pipeline()` primitive runs agent work across a list under the runtime's concurrency limit. The workflow must still preserve the same semantic barrier: schedule the whole fan-out before collecting its first result. Open a CLI dispatch wave only when the workflow surface exposes a distinct native handle for each agent. Otherwise retain the generated workflow script and runtime progress as branch evidence without claiming a CLI-verified wave.
+
+Do not use `claude -p` as a substitute for an available native background Agent or workflow. A shell process farm loses the current session's native scheduling and observability.
+
+## Failure and fallback
+
+If a native launch fails before returning a handle, leave the wave open, fix the launch problem, and retry that leaf. Do not seal a partial wave. If the host has no nonblocking launch capability, record the limitation in `PLAN.md`, execute a declared sequential fallback, and do not open or describe a parallel wave.
+
+Opening a wave is an execution claim. Do not invent handles, record a foreground result as a start, or call simultaneous work proved merely because commands ran quickly.
+
+## Evidence boundary
+
+The launch barrier proves that the host accepted every native start before the driver accepted a return. It does not prove worker honesty, exact CPU overlap, filesystem isolation, or successful integration. Leases, parent re-verification, and branch gates remain separate requirements.

--- a/references/orchestration.md
+++ b/references/orchestration.md
@@ -25,8 +25,8 @@ Use `OPEN`, `VERIFIED`, or `ABANDONED` for branches. Store leaf ledgers as `gate
    ```
 
    A refused claim means the split is not safe for concurrent dispatch. Change the plan or run the work sequentially; never bypass the refusal.
-4. **Dispatch ready leaves.** Give each leaf only the shared contract, its exact ownership and dependencies, its own ledger, and the four-pass completion rule. Do not leak unrelated leaf histories.
-5. **Verify each return independently.** Re-run the returned leaf's runnable gates, including already checked gates:
+4. **Launch each ready wave.** Give each leaf only the shared contract, its exact ownership and dependencies, its own ledger, and the four-pass completion rule. Open a dispatch wave for the independent `READY` leaves, call the host's native nonblocking launch once per leaf, record every host handle, and seal the wave before the first wait or result read. Follow [dispatch.md](dispatch.md); do not leak unrelated leaf histories.
+5. **Verify each return independently.** Record the native return in its wave, then re-run the returned leaf's runnable gates, including already checked gates:
 
    ```text
    node <skill-dir>/scripts/gate-check.mjs --root . --cwd . --reverify .unlazy/<scope>/gates/leaf-1.2.1.md
@@ -53,7 +53,7 @@ Use `--jobs <N>` only when runnable gates are independent and parallel execution
 node <skill-dir>/scripts/gate-check.mjs --root . --cwd . --reverify --jobs 4 .unlazy/<scope>/gates/leaf-1.1.1.md .unlazy/<scope>/gates/leaf-1.1.2.md
 ```
 
-The limit is rolling: start another check when one finishes instead of waiting for a fixed batch. Output and file updates remain deterministic in ledger order. `--jobs` controls command execution, not subagent dispatch and not dependency readiness.
+The limit is rolling: start another check when one finishes instead of waiting for a fixed batch. Output and file updates remain deterministic in ledger order. `--jobs` controls command execution, not subagent dispatch and not dependency readiness. Use [dispatch waves](dispatch.md) for native agent concurrency.
 
 ## Rolling dispatch
 
@@ -61,8 +61,12 @@ Treat dispatch as a loop:
 
 ```text
 while an unverified leaf remains:
-  dispatch each READY leaf whose ownership is claimed
+  collect the independent READY leaves up to the host concurrency limit
+  open a dispatch wave for that exact set
+  launch every native agent and record every returned host handle
+  seal the wave before the first wait
   wait for the next leaf to return
+  record that return in its dispatch wave
   reverify that leaf and review its manual evidence
   append status and update its declared state
   promote each WAITING leaf whose Needs are all VERIFIED
@@ -75,7 +79,7 @@ Do not invent a dependency during dispatch. Add it to `PLAN.md`, correct the aff
 1. **Leaf self-check:** catches ordinary incompleteness but remains self-certification.
 2. **Parent `--reverify`:** executes each runnable oracle again instead of trusting old or manually written evidence.
 3. **Branch integration:** catches locally correct children that do not compose.
-4. **Optional Stop hook:** blocks the driver from ending while its resolved pipeline remains unmet. It scans ledgers; it does not execute checks or validate their meaning.
+4. **Optional Stop hook:** blocks the driver from ending while its resolved pipeline has unmet ledgers or incomplete dispatch waves. It does not execute checks or validate their meaning.
 
 The parent must use the same required toolchain and declared shell. If the environment differs, record and resolve the mismatch instead of accepting old evidence.
 

--- a/scripts/dispatch-check.mjs
+++ b/scripts/dispatch-check.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Records and checks the all-starts-before-wait dispatch contract. Node 16+.
+
+import { resolve } from "node:path";
+import { getDispatchWave, updateDispatch } from "./lib/dispatch.mjs";
+
+const COMMANDS = new Set(["open", "start", "seal", "return", "status"]);
+const args = process.argv.slice(2);
+
+function usage() {
+  return [
+    "Usage:",
+    "  dispatch-check.mjs open --scope ID --wave ID --leaf ID [--leaf ID ...] [--root PATH]",
+    "  dispatch-check.mjs start --scope ID --wave ID --leaf ID --handle OPAQUE_ID [--root PATH]",
+    "  dispatch-check.mjs seal --scope ID --wave ID [--root PATH]",
+    "  dispatch-check.mjs return --scope ID --wave ID --leaf ID [--root PATH]",
+    "  dispatch-check.mjs status --scope ID --wave ID [--root PATH]",
+  ].join("\n");
+}
+
+function die(message) {
+  console.error("unlazy dispatch: " + message);
+  process.exit(2);
+}
+
+if (!args.length || args[0] === "--help" || args[0] === "-h") {
+  console.log(usage());
+  process.exit(args.length ? 0 : 2);
+}
+
+const command = args.shift();
+if (!COMMANDS.has(command)) die("unknown command " + command + "\n" + usage());
+
+const options = { root: process.cwd(), scope: null, wave: null, leaves: [], handle: null };
+const single = new Set();
+while (args.length) {
+  const option = args.shift();
+  if (!["--root", "--scope", "--wave", "--leaf", "--handle"].includes(option)) die("unknown option " + option);
+  if (!args.length || args[0].startsWith("--")) die(option + " requires a value");
+  const value = args.shift();
+  if (option === "--leaf") options.leaves.push(value);
+  else {
+    if (single.has(option)) die(option + " may be provided only once");
+    single.add(option);
+    options[option.slice(2)] = value;
+  }
+}
+
+if (!options.scope) die("--scope is required");
+if (!options.wave) die("--wave is required");
+options.root = resolve(options.root);
+
+if (command === "open") {
+  if (!options.leaves.length) die("open requires at least one --leaf");
+  if (options.handle !== null) die("open does not accept --handle");
+} else if (command === "start") {
+  if (options.leaves.length !== 1) die("start requires exactly one --leaf");
+  if (options.handle === null) die("start requires --handle");
+} else if (command === "return") {
+  if (options.leaves.length !== 1) die("return requires exactly one --leaf");
+  if (options.handle !== null) die("return does not accept --handle");
+} else if (options.leaves.length || options.handle !== null) {
+  die(command + " does not accept --leaf or --handle");
+}
+
+const summary = (wave, id) => {
+  const started = Object.keys(wave.started).length;
+  const returned = Object.keys(wave.returned).length;
+  if (wave.state === "complete") return "COMPLETE " + id + " (" + returned + "/" + wave.leaves.length + " returned)";
+  return wave.state.toUpperCase() + " " + id + " (" + started + "/" + wave.leaves.length +
+    " started, " + returned + "/" + wave.leaves.length + " returned)";
+};
+
+try {
+  if (command === "status") {
+    const wave = getDispatchWave(options.root, options.scope, options.wave);
+    console.log(summary(wave, options.wave));
+    process.exit(wave.state === "complete" ? 0 : 1);
+  }
+
+  const wave = await updateDispatch(options.root, {
+    action: command,
+    scope: options.scope,
+    wave: options.wave,
+    leaves: options.leaves,
+    leaf: options.leaves[0],
+    handle: options.handle,
+  });
+  const started = Object.keys(wave.started).length;
+  const returned = Object.keys(wave.returned).length;
+  if (command === "open") console.log("OPEN " + options.wave + " (0/" + wave.leaves.length + " started, 0/" + wave.leaves.length + " returned)");
+  else if (command === "start") console.log("STARTED " + options.wave + " " + options.leaves[0] + " (" + started + "/" + wave.leaves.length + " started)");
+  else if (command === "seal") console.log("SEALED " + options.wave + " (" + started + "/" + wave.leaves.length + " started)");
+  else if (wave.state === "complete") console.log("COMPLETE " + options.wave + " (" + returned + "/" + wave.leaves.length + " returned)");
+  else console.log("RETURNED " + options.wave + " " + options.leaves[0] + " (" + returned + "/" + wave.leaves.length + " returned)");
+} catch (error) {
+  die(error.message);
+}

--- a/scripts/lib/dispatch.mjs
+++ b/scripts/lib/dispatch.mjs
@@ -10,7 +10,8 @@ const SCHEMA = 1;
 const STATES = new Set(["open", "sealed", "complete"]);
 const CONTROL = /[\u0000-\u001f\u007f]/;
 
-const emptyState = () => ({ schema: SCHEMA, waves: {} });
+const record = (value = {}) => Object.assign(Object.create(null), value);
+const emptyState = () => ({ schema: SCHEMA, waves: record() });
 const count = (record) => Object.keys(record).length;
 
 function fail(message) { throw new Error(message); }
@@ -40,6 +41,7 @@ function validateState(state) {
       !state.waves || typeof state.waves !== "object" || Array.isArray(state.waves)) {
     fail("expected schema 1 with a waves object");
   }
+  state.waves = record(state.waves);
 
   for (const [waveId, wave] of Object.entries(state.waves)) {
     validId(waveId, "wave");
@@ -49,6 +51,8 @@ function validateState(state) {
         !wave.returned || typeof wave.returned !== "object" || Array.isArray(wave.returned)) {
       fail("wave " + waveId + " has an invalid shape");
     }
+    wave.started = record(wave.started);
+    wave.returned = record(wave.returned);
     validTime(wave.openedAt, "wave " + waveId + " openedAt");
     const leaves = new Set();
     for (const leaf of wave.leaves) {
@@ -137,7 +141,7 @@ export async function updateDispatch(root, spec) {
         if (seen.has(leaf)) fail("duplicate leaf " + leaf);
         seen.add(leaf);
       }
-      state.waves[waveId] = { leaves, state: "open", openedAt: now, started: {}, returned: {} };
+      state.waves[waveId] = { leaves, state: "open", openedAt: now, started: record(), returned: record() };
       event = "dispatch " + waveId + " opened: " + leaves.join(", ");
     } else {
       const current = state.waves[waveId];

--- a/scripts/lib/dispatch.mjs
+++ b/scripts/lib/dispatch.mjs
@@ -1,0 +1,183 @@
+// Atomic host-dispatch wave state. Zero dependencies. Node 16+.
+
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  appendStatus, scopeRoot, validateScopeId, withFileLock, writeAtomic,
+} from "./gates.mjs";
+
+const SCHEMA = 1;
+const STATES = new Set(["open", "sealed", "complete"]);
+const CONTROL = /[\u0000-\u001f\u007f]/;
+
+const emptyState = () => ({ schema: SCHEMA, waves: {} });
+const count = (record) => Object.keys(record).length;
+
+function fail(message) { throw new Error(message); }
+
+function validId(value, label) {
+  const error = validateScopeId(value, label);
+  if (error) fail(error);
+  return String(value);
+}
+
+function validHandle(value) {
+  const handle = String(value || "").trim();
+  if (!handle || handle.length > 256 || CONTROL.test(handle)) {
+    fail("handle must be printable, nonblank, and at most 256 characters");
+  }
+  return handle;
+}
+
+function validTime(value, label) {
+  if (typeof value !== "string" || !value || Number.isNaN(Date.parse(value))) {
+    fail(label + " must be an ISO timestamp");
+  }
+}
+
+function validateState(state) {
+  if (!state || typeof state !== "object" || Array.isArray(state) || state.schema !== SCHEMA ||
+      !state.waves || typeof state.waves !== "object" || Array.isArray(state.waves)) {
+    fail("expected schema 1 with a waves object");
+  }
+
+  for (const [waveId, wave] of Object.entries(state.waves)) {
+    validId(waveId, "wave");
+    if (!wave || typeof wave !== "object" || Array.isArray(wave) || !STATES.has(wave.state) ||
+        !Array.isArray(wave.leaves) || !wave.leaves.length ||
+        !wave.started || typeof wave.started !== "object" || Array.isArray(wave.started) ||
+        !wave.returned || typeof wave.returned !== "object" || Array.isArray(wave.returned)) {
+      fail("wave " + waveId + " has an invalid shape");
+    }
+    validTime(wave.openedAt, "wave " + waveId + " openedAt");
+    const leaves = new Set();
+    for (const leaf of wave.leaves) {
+      const id = validId(leaf, "leaf");
+      if (leaves.has(id)) fail("wave " + waveId + " has duplicate leaf " + id);
+      leaves.add(id);
+    }
+
+    const handles = new Set();
+    for (const [leaf, start] of Object.entries(wave.started)) {
+      if (!leaves.has(leaf)) fail("wave " + waveId + " started unknown leaf " + leaf);
+      if (!start || typeof start !== "object" || Array.isArray(start)) fail("wave " + waveId + " has invalid start for " + leaf);
+      const handle = validHandle(start.handle);
+      if (handles.has(handle)) fail("wave " + waveId + " reuses handle " + handle);
+      handles.add(handle);
+      validTime(start.at, "wave " + waveId + " start time for " + leaf);
+    }
+
+    for (const [leaf, returned] of Object.entries(wave.returned)) {
+      if (!leaves.has(leaf) || !wave.started[leaf]) fail("wave " + waveId + " returned unstarted leaf " + leaf);
+      if (!returned || typeof returned !== "object" || Array.isArray(returned)) fail("wave " + waveId + " has invalid return for " + leaf);
+      validTime(returned.at, "wave " + waveId + " return time for " + leaf);
+    }
+
+    const allStarted = count(wave.started) === wave.leaves.length;
+    const allReturned = count(wave.returned) === wave.leaves.length;
+    if (wave.state === "open" && count(wave.returned)) fail("open wave " + waveId + " contains returns");
+    if (wave.state !== "open" && !allStarted) fail(wave.state + " wave " + waveId + " is missing starts");
+    if (wave.state === "complete" && !allReturned) fail("complete wave " + waveId + " is missing returns");
+    if (wave.state === "sealed" && allReturned) fail("sealed wave " + waveId + " should be complete");
+  }
+  return state;
+}
+
+function readState(path) {
+  if (!existsSync(path)) return emptyState();
+  try {
+    if (lstatSync(path).isSymbolicLink()) fail("refusing dispatch state symlink");
+    return validateState(JSON.parse(readFileSync(path, "utf8")));
+  } catch (error) {
+    if (String(error.message).startsWith("invalid dispatch state:")) throw error;
+    throw new Error("invalid dispatch state: " + error.message);
+  }
+}
+
+export function dispatchStatePath(root, scope) {
+  return join(scopeRoot(resolve(root), validId(scope, "scope")), "dispatch.json");
+}
+
+export function getDispatchWave(root, scope, waveId) {
+  const wave = validId(waveId, "wave");
+  const state = readState(dispatchStatePath(root, scope));
+  if (!state.waves[wave]) fail("unknown wave " + wave);
+  return state.waves[wave];
+}
+
+export function dispatchIssues(root, scope) {
+  if (!scope) return [];
+  let state;
+  try { state = readState(dispatchStatePath(root, scope)); }
+  catch (error) { return ["dispatch:PARSE " + error.message]; }
+  return Object.entries(state.waves).sort(([left], [right]) => left.localeCompare(right)).flatMap(([id, wave]) => {
+    if (wave.state === "complete") return [];
+    if (wave.state === "open") return ["dispatch:" + id + " open (" + count(wave.started) + "/" + wave.leaves.length + " started)"];
+    return ["dispatch:" + id + " sealed (" + count(wave.returned) + "/" + wave.leaves.length + " returned)"];
+  });
+}
+
+export async function updateDispatch(root, spec) {
+  const scope = validId(spec.scope, "scope");
+  const waveId = validId(spec.wave, "wave");
+  const path = dispatchStatePath(root, scope);
+  let event = "";
+
+  const wave = await withFileLock(root, path, () => {
+    const state = readState(path);
+    const now = spec.now || new Date().toISOString();
+    validTime(now, "timestamp");
+
+    if (spec.action === "open") {
+      if (state.waves[waveId]) fail("wave " + waveId + " already exists");
+      const leaves = (spec.leaves || []).map((leaf) => validId(leaf, "leaf"));
+      if (!leaves.length) fail("open requires at least one --leaf");
+      const seen = new Set();
+      for (const leaf of leaves) {
+        if (seen.has(leaf)) fail("duplicate leaf " + leaf);
+        seen.add(leaf);
+      }
+      state.waves[waveId] = { leaves, state: "open", openedAt: now, started: {}, returned: {} };
+      event = "dispatch " + waveId + " opened: " + leaves.join(", ");
+    } else {
+      const current = state.waves[waveId];
+      if (!current) fail("unknown wave " + waveId);
+      if (spec.action === "start") {
+        const leaf = validId(spec.leaf, "leaf");
+        const handle = validHandle(spec.handle);
+        if (current.state !== "open") fail("wave " + waveId + " is " + current.state + "; start requires an open wave");
+        if (!current.leaves.includes(leaf)) fail("unknown leaf " + leaf + " in wave " + waveId);
+        if (current.started[leaf]) fail("leaf " + leaf + " already started");
+        const owner = Object.entries(current.started).find(([, start]) => start.handle === handle);
+        if (owner) fail("handle is already assigned to " + owner[0]);
+        current.started[leaf] = { handle, at: now };
+        event = "dispatch " + waveId + " started " + leaf + " as " + handle;
+      } else if (spec.action === "seal") {
+        if (current.state !== "open") fail("wave " + waveId + " is " + current.state + "; seal requires an open wave");
+        const missing = current.leaves.filter((leaf) => !current.started[leaf]);
+        if (missing.length) fail("cannot seal " + waveId + ": missing starts for " + missing.join(", "));
+        current.state = "sealed";
+        current.sealedAt = now;
+        event = "dispatch " + waveId + " sealed";
+      } else if (spec.action === "return") {
+        const leaf = validId(spec.leaf, "leaf");
+        if (current.state === "open") fail("return requires a sealed wave; " + waveId + " is open");
+        if (!current.leaves.includes(leaf)) fail("unknown leaf " + leaf + " in wave " + waveId);
+        if (current.returned[leaf]) fail("leaf " + leaf + " already returned");
+        current.returned[leaf] = { at: now };
+        if (count(current.returned) === current.leaves.length) {
+          current.state = "complete";
+          current.completedAt = now;
+        }
+        event = "dispatch " + waveId + " returned " + leaf;
+      } else fail("unknown dispatch action " + spec.action);
+    }
+
+    validateState(state);
+    writeAtomic(path, JSON.stringify(state, null, 2) + "\n", { root });
+    return state.waves[waveId];
+  });
+
+  appendStatus(root, scope, new Date().toISOString() + " " + event);
+  return wave;
+}

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -7,6 +7,7 @@ import {
   UNLAZY_DIR, gateState, hookStatePath, parseGates, qualify, resolveTarget,
   sha256, validateScopeId, withFileLock, writeAtomic,
 } from "./lib/gates.mjs";
+import { dispatchIssues } from "./lib/dispatch.mjs";
 
 const MAX_BLOCKS = 6;
 const args = process.argv.slice(2);
@@ -58,14 +59,16 @@ async function clearSessionState() {
   }
 }
 
-if (!target.files.length) {
+const dispatch = dispatchIssues(root, target.scope);
+
+if (!target.files.length && !dispatch.length) {
   await clearSessionState();
   allow(null);
 }
 
-const unmet = [];
+const unmet = [...dispatch];
 const invalid = [];
-let combined = "";
+let combined = "dispatch\0" + dispatch.join("\0") + "\0";
 for (const file of [...target.files].sort()) {
   let text;
   try { text = readFileSync(file, "utf8"); }
@@ -125,7 +128,7 @@ if (sessionState.blocks > MAX_BLOCKS) {
 const list = outstanding.slice(0, 5).join(", ") + (outstanding.length > 5 ? ", +" + (outstanding.length - 5) + " more" : "");
 console.log(JSON.stringify({
   decision: "block",
-  reason: "unlazy" + where + ": " + outstanding.length + " gate/ledger item(s) need work: " + list +
+  reason: "unlazy" + where + ": " + outstanding.length + " gate/ledger/dispatch item(s) need work: " + list +
     ". Run gate-check.mjs --status to inspect without execution. To run inherited CHECK lines, inspect them and use --approve. " +
     "Use ABANDON: <id> <non-blank reason> only when a gate is genuinely impossible.",
 }));

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -11,6 +11,8 @@ Decide before fan-out:
 - Interfaces: <signatures, schemas, formats, integration points>
 - Ownership: <one complete set of repository-relative paths per leaf; no absolute paths, traversal, or concurrent overlap>
 - Dependencies: <leaf ids that must be VERIFIED first>
+- Host launch mode: <Codex native subagents | Claude background Agents | Claude Dynamic Workflow | sequential fallback>
+- Wave policy: <which independent READY leaves launch together and the maximum host concurrency>
 - Toolchain: <runtime versions, shell, working-directory rules, test commands>
 - Conventions: <naming, errors, compatibility, formatting>
 - Manual review: <owner and evidence standard for consequential manual gates>
@@ -39,7 +41,7 @@ Use `leaf-` paths for work leaves and `node-` paths for branch integration.
     - 1.2.1 <leaf> ...... gates/leaf-1.2.1.md .......... Needs: - ...... State: READY
     - 1.2.2 <leaf> ...... gates/leaf-1.2.2.md .......... Needs: 1.2.1 .. State: WAITING
 
-Every leaf repeats its complete ownership as an `OWNS:` header in its ledger. Claim each concurrently dispatched leaf with `--claim` before changing its state to IN-FLIGHT.
+Every leaf repeats its complete ownership as an `OWNS:` header in its ledger. Claim each concurrently dispatched leaf with `--claim`, then open and seal a native launch wave as described in `references/dispatch.md` before changing its state to IN-FLIGHT.
 
 ## Status log
 

--- a/tests/dispatch-tests.mjs
+++ b/tests/dispatch-tests.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Black-box tests for dispatch launch barriers. Zero dependencies, Node 16+.
+
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DISPATCH_CHECK = join(HERE, "..", "scripts", "dispatch-check.mjs");
+const filter = process.argv[2] || "";
+const tests = [];
+
+const test = (name, fn) => tests.push({ name, fn });
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+const assertHas = (value, expected) => {
+  assert(value.includes(expected), "output missing " + JSON.stringify(expected) + "\n--- got ---\n" + value);
+};
+
+function sandbox() {
+  const dir = mkdtempSync(join(tmpdir(), "unlazy-dispatch-test-"));
+  return {
+    dir,
+    write(relative, value) {
+      const file = join(dir, relative);
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, value);
+    },
+    read(relative) { return readFileSync(join(dir, relative), "utf8"); },
+    cleanup() { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } },
+  };
+}
+
+function run(args, options = {}) {
+  return new Promise((resolveResult) => {
+    execFile(process.execPath, [DISPATCH_CHECK, ...args], {
+      cwd: options.cwd,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    }, (error, stdout, stderr) => {
+      resolveResult({
+        code: error ? (error.code ?? 1) : 0,
+        out: (stdout || "") + (stderr || ""),
+      });
+    });
+  });
+}
+
+const base = (command, wave = "ready-1") => [command, "--scope", "api", "--wave", wave];
+
+test("barrier: every leaf must start before seal or return", async () => {
+  const s = sandbox();
+  try {
+    let result = await run([...base("open"), "--leaf", "leaf-a", "--leaf", "leaf-b"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    assertHas(result.out, "OPEN ready-1 (0/2 started, 0/2 returned)");
+
+    result = await run([...base("start"), "--leaf", "leaf-a", "--handle", "codex:a"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+
+    result = await run([...base("return"), "--leaf", "leaf-a"], { cwd: s.dir });
+    assert(result.code === 2, "premature return should exit 2, got " + result.code);
+    assertHas(result.out, "return requires a sealed wave");
+
+    result = await run(base("seal"), { cwd: s.dir });
+    assert(result.code === 2, "incomplete seal should exit 2, got " + result.code);
+    assertHas(result.out, "missing starts for leaf-b");
+
+    await run([...base("start"), "--leaf", "leaf-b", "--handle", "codex:b"], { cwd: s.dir });
+    result = await run(base("seal"), { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    assertHas(result.out, "SEALED ready-1 (2/2 started)");
+
+    await run([...base("return"), "--leaf", "leaf-b"], { cwd: s.dir });
+    result = await run([...base("return"), "--leaf", "leaf-a"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    assertHas(result.out, "COMPLETE ready-1 (2/2 returned)");
+
+    result = await run(base("status"), { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    assertHas(result.out, "COMPLETE ready-1 (2/2 returned)");
+  } finally { s.cleanup(); }
+});
+
+test("validation: duplicate leaves and duplicate waves are rejected", async () => {
+  const s = sandbox();
+  try {
+    let result = await run([...base("open"), "--leaf", "leaf-a", "--leaf", "leaf-a"], { cwd: s.dir });
+    assert(result.code === 2, "duplicate leaves should exit 2, got " + result.code);
+    assertHas(result.out, "duplicate leaf leaf-a");
+
+    result = await run([...base("open"), "--leaf", "leaf-a"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    result = await run([...base("open"), "--leaf", "leaf-b"], { cwd: s.dir });
+    assert(result.code === 2, "duplicate wave should exit 2, got " + result.code);
+    assertHas(result.out, "wave ready-1 already exists");
+  } finally { s.cleanup(); }
+});
+
+test("validation: unknown leaves and reused handles are rejected", async () => {
+  const s = sandbox();
+  try {
+    await run([...base("open"), "--leaf", "leaf-a", "--leaf", "leaf-b"], { cwd: s.dir });
+    let result = await run([...base("start"), "--leaf", "leaf-c", "--handle", "codex:c"], { cwd: s.dir });
+    assert(result.code === 2, "unknown leaf should exit 2, got " + result.code);
+    assertHas(result.out, "unknown leaf leaf-c");
+
+    await run([...base("start"), "--leaf", "leaf-a", "--handle", "codex:shared"], { cwd: s.dir });
+    result = await run([...base("start"), "--leaf", "leaf-b", "--handle", "codex:shared"], { cwd: s.dir });
+    assert(result.code === 2, "duplicate handle should exit 2, got " + result.code);
+    assertHas(result.out, "handle is already assigned to leaf-a");
+
+    result = await run([...base("start"), "--leaf", "leaf-a", "--handle", "codex:again"], { cwd: s.dir });
+    assert(result.code === 2, "duplicate start should exit 2, got " + result.code);
+    assertHas(result.out, "leaf leaf-a already started");
+  } finally { s.cleanup(); }
+});
+
+test("locking: simultaneous start records are not lost", async () => {
+  const s = sandbox();
+  try {
+    const leaves = ["leaf-a", "leaf-b", "leaf-c", "leaf-d"];
+    await run([...base("open"), ...leaves.flatMap((leaf) => ["--leaf", leaf])], { cwd: s.dir });
+    const results = await Promise.all(leaves.map((leaf) =>
+      run([...base("start"), "--leaf", leaf, "--handle", "codex:" + leaf], { cwd: s.dir })));
+    assert(results.every((result) => result.code === 0), results.map((result) => result.out).join("\n"));
+
+    const state = JSON.parse(s.read(".unlazy/api/dispatch.json"));
+    assert(Object.keys(state.waves["ready-1"].started).length === 4,
+      "expected four persisted starts, got " + JSON.stringify(state));
+    const sealed = await run(base("seal"), { cwd: s.dir });
+    assert(sealed.code === 0, sealed.out);
+  } finally { s.cleanup(); }
+});
+
+test("validation: malformed ids, handles, and state fail closed", async () => {
+  const s = sandbox();
+  try {
+    let result = await run(["open", "--scope", "../api", "--wave", "ready-1", "--leaf", "leaf-a"], { cwd: s.dir });
+    assert(result.code === 2, "invalid scope should exit 2, got " + result.code);
+    assertHas(result.out, "scope must match");
+
+    await run([...base("open"), "--leaf", "leaf-a"], { cwd: s.dir });
+    result = await run([...base("start"), "--leaf", "leaf-a", "--handle", "bad\nhandle"], { cwd: s.dir });
+    assert(result.code === 2, "control character should exit 2, got " + result.code);
+    assertHas(result.out, "handle must be printable");
+
+    s.write(".unlazy/api/dispatch.json", "{not json\n");
+    result = await run(base("status"), { cwd: s.dir });
+    assert(result.code === 2, "malformed state should exit 2, got " + result.code);
+    assertHas(result.out, "invalid dispatch state");
+  } finally { s.cleanup(); }
+});
+
+const selected = tests.filter(({ name }) => name.includes(filter));
+let passed = 0;
+const failures = [];
+
+for (const current of selected) {
+  try {
+    await current.fn();
+    passed += 1;
+    console.log("ok   " + current.name);
+  } catch (error) {
+    failures.push({ name: current.name, error });
+    console.log("FAIL " + current.name + "\n     " + String(error.message).split("\n").join("\n     "));
+  }
+}
+
+console.log("\n" + passed + "/" + selected.length + " passed");
+process.exit(failures.length ? 1 : 0);

--- a/tests/dispatch-tests.mjs
+++ b/tests/dispatch-tests.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DISPATCH_CHECK = join(HERE, "..", "scripts", "dispatch-check.mjs");
+const STOP_HOOK = join(HERE, "..", "scripts", "stop-hook.mjs");
 const filter = process.argv[2] || "";
 const tests = [];
 
@@ -32,9 +33,9 @@ function sandbox() {
   };
 }
 
-function run(args, options = {}) {
+function runScript(script, args, options = {}) {
   return new Promise((resolveResult) => {
-    execFile(process.execPath, [DISPATCH_CHECK, ...args], {
+    const child = execFile(process.execPath, [script, ...args], {
       cwd: options.cwd,
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -44,7 +45,29 @@ function run(args, options = {}) {
         out: (stdout || "") + (stderr || ""),
       });
     });
+    if (options.stdin !== undefined) child.stdin.end(options.stdin);
   });
+}
+
+const run = (args, options = {}) => runScript(DISPATCH_CHECK, args, options);
+
+function launchTimedWorker(directory, name, durationMs = 600) {
+  const output = join(directory, name + ".json");
+  const source = [
+    "const fs = require('fs')",
+    "const output = process.argv[1]",
+    "const duration = Number(process.argv[2])",
+    "const start = Date.now()",
+    "setTimeout(() => fs.writeFileSync(output, JSON.stringify({ start, end: Date.now() })), duration)",
+  ].join(";");
+  let child;
+  const done = new Promise((resolveResult, reject) => {
+    child = execFile(process.execPath, ["-e", source, output, String(durationMs)], { cwd: directory }, (error) => {
+      if (error) reject(error);
+      else resolveResult(JSON.parse(readFileSync(output, "utf8")));
+    });
+  });
+  return { handle: "pid:" + child.pid, done };
 }
 
 const base = (command, wave = "ready-1") => [command, "--scope", "api", "--wave", wave];
@@ -150,6 +173,50 @@ test("validation: malformed ids, handles, and state fail closed", async () => {
     result = await run(base("status"), { cwd: s.dir });
     assert(result.code === 2, "malformed state should exit 2, got " + result.code);
     assertHas(result.out, "invalid dispatch state");
+  } finally { s.cleanup(); }
+});
+
+test("hook: an incomplete dispatch wave blocks an otherwise complete scope", async () => {
+  const s = sandbox();
+  try {
+    s.write(".unlazy/api/GATES.md", "# Gates\n\n- [x] G1: complete\n  EVIDENCE: checked by test\n");
+    await run([...base("open"), "--leaf", "leaf-a", "--leaf", "leaf-b"], { cwd: s.dir });
+    await run([...base("start"), "--leaf", "leaf-a", "--handle", "codex:a"], { cwd: s.dir });
+
+    const stdin = JSON.stringify({ cwd: s.dir, session_id: "dispatch-hook-test" });
+    let result = await runScript(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+    assertHas(result.out, '"decision":"block"');
+    assertHas(result.out, "dispatch:ready-1");
+
+    await run([...base("start"), "--leaf", "leaf-b", "--handle", "codex:b"], { cwd: s.dir });
+    await run(base("seal"), { cwd: s.dir });
+    await run([...base("return"), "--leaf", "leaf-a"], { cwd: s.dir });
+    await run([...base("return"), "--leaf", "leaf-b"], { cwd: s.dir });
+    result = await runScript(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+    assert(result.out.trim() === "", "complete dispatch should allow Stop, got " + result.out);
+  } finally { s.cleanup(); }
+});
+
+test("overlap: native starts precede waits and workers run simultaneously", async () => {
+  const s = sandbox();
+  try {
+    await run([...base("open"), "--leaf", "leaf-a", "--leaf", "leaf-b"], { cwd: s.dir });
+
+    const a = launchTimedWorker(s.dir, "leaf-a");
+    await run([...base("start"), "--leaf", "leaf-a", "--handle", a.handle], { cwd: s.dir });
+    const b = launchTimedWorker(s.dir, "leaf-b");
+    await run([...base("start"), "--leaf", "leaf-b", "--handle", b.handle], { cwd: s.dir });
+    await run(base("seal"), { cwd: s.dir });
+
+    const [aTiming, bTiming] = await Promise.all([a.done, b.done]);
+    const overlap = Math.min(aTiming.end, bTiming.end) - Math.max(aTiming.start, bTiming.start);
+    assert(overlap > 0, "expected worker execution intervals to overlap, got " + overlap + "ms");
+
+    await run([...base("return"), "--leaf", "leaf-a"], { cwd: s.dir });
+    await run([...base("return"), "--leaf", "leaf-b"], { cwd: s.dir });
+    const status = await run(base("status"), { cwd: s.dir });
+    assert(status.code === 0, status.out);
+    assertHas(status.out, "COMPLETE ready-1 (2/2 returned)");
   } finally { s.cleanup(); }
 });
 

--- a/tests/dispatch-tests.mjs
+++ b/tests/dispatch-tests.mjs
@@ -176,6 +176,19 @@ test("validation: malformed ids, handles, and state fail closed", async () => {
   } finally { s.cleanup(); }
 });
 
+test("validation: legal ids cannot collide with object prototypes", async () => {
+  const s = sandbox();
+  try {
+    const special = ["open", "--scope", "api", "--wave", "toString"];
+    let result = await run([...special, "--leaf", "constructor"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    result = await run(["start", "--scope", "api", "--wave", "toString", "--leaf", "constructor", "--handle", "codex:special"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+    result = await run(["seal", "--scope", "api", "--wave", "toString"], { cwd: s.dir });
+    assert(result.code === 0, result.out);
+  } finally { s.cleanup(); }
+});
+
 test("hook: an incomplete dispatch wave blocks an otherwise complete scope", async () => {
   const s = sandbox();
   try {


### PR DESCRIPTION
## Failure

Orchestrated mode could identify independent `READY` leaves but did not define or enforce the boundary between native agent launch and result collection. A host could launch one worker, wait for it, then launch the next while still appearing to follow the rolling-dispatch prose. `--jobs` only parallelizes approved gate commands; it does not create agent sessions.

## Contract after this change

- Add atomic dispatch waves under `.unlazy/<scope>/dispatch.json`.
- Require every declared leaf to receive a distinct native host handle before a wave can seal.
- Reject every worker return until its wave is sealed, which makes the serial launch-then-wait pattern invalid.
- Block Claude Code Stop while a wave is open or has unreturned workers.
- Document native adapters for [Codex subagents](https://developers.openai.com/codex/agent-configuration/subagents), [Claude Code background subagents](https://code.claude.com/docs/en/sub-agents#run-subagents-in-foreground-or-background), and large Claude [Dynamic Workflows](https://code.claude.com/docs/en/workflows).
- Keep Unlazy zero-dependency and host-native. This does not add `codex exec`, `claude -p`, provider credentials, or a model subprocess farm.

The evidence claim stays narrow: a sealed wave proves the host returned every native start handle before Unlazy accepted a result. It does not claim worker honesty, filesystem isolation, successful gates, integration, or exact CPU scheduling.

## Regression evidence

- Local `npm test` on Node.js 24.10.0: 72 tests passed: 26 core, 8 dispatch, 19 hardening, 10 stress, and 9 self-checks.
- The dispatch suite rejects premature returns, incomplete seals, unknown leaves, duplicate handles, concurrent lost updates, malformed state, and object-prototype ID collisions.
- The fake native adapter launches two timed workers before its first wait and asserts that their measured execution intervals overlap.
- `node --check` passes for `dispatch-check.mjs`, `lib/dispatch.mjs`, and `stop-hook.mjs`.
- `git diff upstream/main...HEAD --check` passes.

The Node.js 16 API floor and zero runtime dependencies are preserved. The upstream 3-OS by 3-Node workflow is currently `action_required` with no jobs because this fork run needs maintainer authorization; that matrix has not executed yet.
