### PR TITLE
fix(win32): kill entire process tree on timeout to prevent orphaned processes

### DIFF
--- a/scripts/gate-check.mjs
+++ b/scripts/gate-check.mjs
@@ -6,7 +6,7 @@ import {
   closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync,
   statSync, unlinkSync, writeFileSync,
 } from "node:fs";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { Worker } from "node:worker_threads";
 import { randomBytes } from "node:crypto";
 import { delimiter, dirname, basename, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -437,7 +437,7 @@ function runCheck(task) {
     const stopChild = () => {
       if (closeStreamsTimer) return;
       try {
-        if (process.platform === "win32") child.kill("SIGKILL");
+        if (process.platform === "win32") spawnSync("taskkill", ["/pid", child.pid, "/f", "/t"], { stdio: "ignore" });
         else process.kill(-child.pid, "SIGKILL");
       } catch {
         try { child.kill("SIGKILL"); } catch { /* already gone */ }


### PR DESCRIPTION
## The failure
On Windows, `gate-check.mjs` launches checks using `cmd.exe` (since `shell` defaults to `cmd.exe` on win32). When a timeout occurs, the script previously called `child.kill("SIGKILL")`. 
In Node.js, calling `.kill()` on a process spawned with a shell only kills the shell itself (`cmd.exe`). Any long-running subprocess running inside it (like a hanging test or a node script) gets orphaned and continues running infinitely in the background as a zombie process, silently leaking CPU/RAM.
## The contract after the change
- On `win32`, the runner now synchronously invokes `taskkill /pid <PID> /f /t`.
- The `/t` (tree) flag ensures the shell and all of its descendants are forcefully terminated, matching the exact process-group kill behavior `process.kill(-child.pid, "SIGKILL")` provides on Unix.
- Node.js zero-dependency floor is fully preserved (`spawnSync` from `node:child_process`).
## Regression evidence
Local `npm test` on Windows passes cleanly (26 core, 19 hardening, 10 stress, 9 self-checks). 
Tested manually on a `GATES.md` containing a 300-second sleep timeout: the zombie `node.exe` subprocess is now correctly reaped on timeout.
