### PR TITLE
fix: diagnose an indented ABANDON instead of ignoring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This section describes the current source tree. It does not claim that `2.1.0` h
 - Add `--reverify` so parent verification executes already checked runnable gates and removes completion when the oracle no longer passes.
 - Require both process exit `0` and `EXPECT:` match. Include resolved shell, resolved working directory, exit status, and decisive output in evidence and diagnostics.
 - Discard an in-flight result when the gate's bound oracle changes before writeback.
+- Diagnose an indented `ABANDON:` instead of ignoring it. Attributes must be indented and `ABANDON:` must not be, so the natural formatting mistake previously left a gate unmet and the honest exit unexplained.
 
 ### Command trust and portability
 

--- a/references/gates.md
+++ b/references/gates.md
@@ -38,6 +38,7 @@ The fenced example above is documentation. Lines inside fenced code blocks are i
 - Use one `EVIDENCE:` line per gate. If it is omitted from an otherwise valid gate, the checker inserts it without changing the file's original CRLF or LF newline style.
 - Put the optional `OWNS:` header before the first gate. Separate paths with commas. Paths are repository-relative globs; absolute paths and traversal segments such as `..` are invalid.
 - Write `ABANDON: <id> <reason>` only for a gate in the same file. The reason must contain non-whitespace text. An unknown id is warned and resolves no live gate.
+- Start `ABANDON:` at column 1. It names its gate by id, so it is a file-level statement rather than a gate attribute, and it is the one line that must not be indented. An indented `ABANDON:` is diagnosed rather than applied.
 - Do not define a ledger with zero gates. A named empty or malformed ledger is a parse error, not `ALL MET`.
 - Use `/pattern/flags` for a JavaScript regular-expression expectation or plain text for a substring. An invalid regular expression is a parse error.
 

--- a/scripts/lib/gates.mjs
+++ b/scripts/lib/gates.mjs
@@ -46,6 +46,7 @@ const GATE_RE = /^- \[( |x|X)\] (.*)$/;
 const ATTR_RE = /^(\s+)(CHECK|EXPECT|EVIDENCE|CWD):\s?(.*)$/;
 const UNINDENTED_ATTR_RE = /^(CHECK|EXPECT|EVIDENCE|CWD):\s?(.*)$/;
 const ABANDON_RE = /^ABANDON:\s*(\S*)\s*(.*)$/;
+const INDENTED_ABANDON_RE = /^\s+ABANDON:/;
 const OWNS_RE = /^OWNS:\s*(.*)$/;
 const FENCE_OPEN_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
 const REGEX_RE = /^\/([\s\S]*)\/([a-z]*)$/;
@@ -125,6 +126,16 @@ export function parseGates(text, options = {}) {
         errors.push("line " + (index + 1) + ": duplicate gate id " + id +
           " (first declared on line " + ids.get(id) + ")");
       } else ids.set(id, index + 1);
+      continue;
+    }
+
+    // Attributes must be indented and ABANDON must not be, so the two rules
+    // point opposite ways. Diagnose the indented abandonment rather than
+    // ignoring it, or the author's honest exit fails with no explanation.
+    if (INDENTED_ABANDON_RE.test(line)) {
+      errors.push("line " + (index + 1) +
+        ": indented ABANDON is not applied; start ABANDON at column 1");
+      current = null;
       continue;
     }
 

--- a/tests/hardening-tests.mjs
+++ b/tests/hardening-tests.mjs
@@ -444,6 +444,30 @@ test("leases: unsafe declarations, unknown leaves, and wildcard witnesses fail c
   } finally { s.cleanup(); }
 });
 
+test("parser: an indented ABANDON is diagnosed instead of silently ignored", async () => {
+  const s = sandbox();
+  try {
+    // Every other attribute must be indented, so indenting the abandonment is
+    // the natural mistake. Ignoring the line silently leaves the gate unmet
+    // with no diagnostic, so the honest exit fails for a formatting reason the
+    // author is never told about.
+    s.write("GATES.md", [
+      "# Gates: indented abandonment",
+      "",
+      "Scope: an abandonment indented like every other attribute",
+      "",
+      "- [ ] G1: upstream export reconciles",
+      "  EVIDENCE: pending",
+      "  ABANDON: G1 upstream export was withdrawn",
+      "",
+    ].join("\n"));
+    const result = await gateRun(s, ["--status"], { approve: false });
+    assert(result.code === 2, "expected a parse error, got " + result.code + "\n" + result.out);
+    has(result.out, "indented ABANDON");
+    has(result.out, "column 1");
+  } finally { s.cleanup(); }
+});
+
 let passed = 0;
 const failures = [];
 for (const item of tests) {


### PR DESCRIPTION
## The failure

`ABANDON_RE` is anchored at column 1. `CHECK:`, `EXPECT:`, `CWD:` and `EVIDENCE:` must all be indented beneath their gate. The two rules point opposite ways, and only one of them is enforced.

Indenting the abandonment the way every neighbouring line is indented produces no error and no warning. The line is skipped, the gate stays unmet, and the Stop hook keeps blocking:

```markdown
- [ ] G1: upstream export reconciles
  EVIDENCE: pending
  ABANDON: G1 upstream export was withdrawn
```

```text
$ node scripts/gate-check.mjs --status GATES.md
  UNMET GATES:G1 (unchecked): upstream export reconciles
UNMET: 1 (met: 0)
```

That inverts the intent of the escape hatch. An author reaches for `ABANDON:` precisely when a gate is impossible, and the ledger answers by failing closed for a formatting reason it never reports. The agent has no way to learn what went wrong, so it keeps working an impossible gate until the six-block release fires.

`references/gates.md` documented the reason requirement and the same-file rule, but never the column rule.

## The contract after the change

An indented `ABANDON:` is a parse error naming its line, diagnosed exactly the way an unindented attribute already is:

```text
gate-check: GATES.md: line 7: indented ABANDON is not applied; start ABANDON at column 1
```

A column 1 `ABANDON:` is unchanged. No gate resolves that did not resolve before, so this only converts a silent failure into a loud one. The strict parsing rules now state the column requirement and why it exists: `ABANDON:` names its gate by id, so it is a file-level statement rather than a gate attribute.

## Regression evidence

`tests/hardening-tests.mjs`: `parser: an indented ABANDON is diagnosed instead of silently ignored`. It asserts exit `2` and the diagnostic text.

Fails before the patch:

```text
FAIL parser: an indented ABANDON is diagnosed instead of silently ignored
     expected a parse error, got 1
19/20 passed
```

Passes after, with the full suite green:

```text
26/26 passed          run-tests
20/20 passed          hardening-tests
10/10 passed          stress-tests
self-check ok (9/9)
```

## Notes

Diagnose rather than accept, on purpose. Accepting an indented `ABANDON:` would widen what resolves a gate, which is a fail-open change to completion state. Diagnosing keeps ground rule 3 intact and still tells the author exactly what to fix.

No format change beyond the diagnostic, no new dependency, Node 16 stdlib only, no em dash or en dash.
