### PR TITLE
fix: key the Stop-hook loop guard to gate state, not ledger bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This section describes the current source tree. It does not claim that `2.1.0` h
 - Add opt-in `--jobs <N>` rolling check concurrency while retaining sequential default behavior and deterministic ledger-order reporting.
 - Add declared readiness states, real `node-*` branch paths, explicit dependencies, and rolling leaf dispatch to the plan and orchestration guide.
 - Key Stop-hook progress state to the session and scope, serialize state changes, and retain unlazy's own six-block no-progress release.
+- Compare resolved gate state between stops rather than raw ledger bytes. A comment, a reflowed line, or a rewritten evidence line no longer counts as progress, so the six-block release can fire for an agent that is editing without advancing.
 
 ### Installer, package, and documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -79,7 +79,7 @@ Offer the hook once when structural stop enforcement would materially help. Neve
 node <skill-dir>/scripts/install-hooks.mjs
 ```
 
-The hook returns Claude Code's top-level `decision: "block"` response while this session's resolved pipeline has unmet gates. Its own session-keyed progress guard releases after six consecutive blocks without ledger progress. Remove it with `--uninstall`.
+The hook returns Claude Code's top-level `decision: "block"` response while this session's resolved pipeline has unmet gates. Its own session-keyed progress guard releases after six consecutive blocks without a change in resolved gate state. Editing a ledger is not progress; meeting, abandoning, or invalidating a gate is. Remove it with `--uninstall`.
 
 Default installation writes machine-specific project-local settings. Keep `.claude/settings.local.json`, `.unlazy/`, and `.unlazy-hook-state.json` in the project's ignore rules. Shared installation contains absolute Node and hook-script paths and is usually not portable across machines. Read [SECURITY.md](SECURITY.md) before choosing an install target.
 

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -65,22 +65,31 @@ if (!target.files.length) {
 
 const unmet = [];
 const invalid = [];
-let combined = "";
+// The loop guard compares resolved gate state between stops, not raw bytes.
+// Byte comparison counted any edit as progress: a comment, a reflowed line, or
+// the checker rewriting an evidence line with a fresh PATH hash. That rearmed
+// the guard indefinitely, so the six-block release could only ever fire for an
+// agent doing literally nothing, which is the one case least in need of it.
+const resolved = [];
 for (const file of [...target.files].sort()) {
   let text;
   try { text = readFileSync(file, "utf8"); }
   catch (error) {
     invalid.push(qualify(file, "PARSE") + " unreadable: " + error.message);
+    resolved.push(qualify(file, "PARSE") + "=unreadable");
     continue;
   }
-  combined += file + "\0" + text + "\0";
   const doc = parseGates(text);
   if (doc.errors.length) {
     invalid.push(qualify(file, "PARSE") + " " + doc.errors.slice(0, 2).join("; "));
+    // Record only that the ledger is invalid. Diagnostic text carries line
+    // numbers, which shift on an unrelated edit and would restore byte coupling.
+    resolved.push(qualify(file, "PARSE") + "=invalid");
     continue;
   }
   for (const gate of doc.gates) {
     const state = gateState(gate, doc.abandoned);
+    resolved.push(qualify(file, gate.id) + "=" + state);
     if (state === "unmet" || state === "unmet-no-evidence") unmet.push(qualify(file, gate.id));
   }
 }
@@ -90,7 +99,7 @@ if (!unmet.length && !invalid.length) {
   allow(null);
 }
 
-const contentHash = sha256(combined + invalid.join("\0")).slice(0, 24);
+const progressHash = sha256(resolved.sort().join("\0")).slice(0, 24);
 let sessionState;
 try {
   sessionState = await withFileLock(root, statePath, () => {
@@ -101,7 +110,7 @@ try {
       state = { schema: 1, sessions: {} };
     }
     let current = state.sessions[sessionKey];
-    if (!current || current.hash !== contentHash) current = { hash: contentHash, blocks: 0 };
+    if (!current || current.hash !== progressHash) current = { hash: progressHash, blocks: 0 };
     current.blocks += 1;
     current.updatedAt = new Date().toISOString();
     state.sessions[sessionKey] = current;

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -346,6 +346,43 @@ test("hook: each pipeline keeps its own loop-guard counter", async () => {
   } finally { s.cleanup(); }
 });
 
+test("hook: the loop guard tracks gate state, not file bytes", async () => {
+  const s = sandbox();
+  try {
+    // A cosmetic edit is not progress. Keying the guard to raw bytes let any
+    // touch of the ledger reset the counter, so an agent that keeps editing
+    // without meeting a gate is never released. Re-running the checker did the
+    // same thing by rewriting evidence text.
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "a", null, null) + gate("G2", "b", null, null));
+    const stdin = JSON.stringify({ cwd: s.dir });
+    for (let i = 0; i < 6; i++) {
+      const blocked = await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+      assertHas(blocked.out, '"decision":"block"');
+    }
+    s.write(".unlazy/api/gates/leaf-1.md",
+      s.read(".unlazy/api/gates/leaf-1.md") + "\n<!-- still thinking about it -->\n");
+    const afterCosmetic = await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+    assertHas(afterCosmetic.out, "releasing after 6 blocks");
+  } finally { s.cleanup(); }
+});
+
+test("hook: meeting a gate resets the loop guard", async () => {
+  const s = sandbox();
+  try {
+    // The converse of the test above: real progress must still rearm the guard,
+    // or a long run would be released while it is genuinely advancing.
+    s.write(".unlazy/api/gates/leaf-1.md", "# Gates\n\n" + gate("G1", "a", null, null) + gate("G2", "b", null, null));
+    const stdin = JSON.stringify({ cwd: s.dir });
+    for (let i = 0; i < 3; i++) await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+    s.write(".unlazy/api/gates/leaf-1.md",
+      "# Gates\n\n- [x] G1: a\n  EVIDENCE: measured 3 of 3\n\n" + gate("G2", "b", null, null));
+    for (let i = 0; i < 4; i++) {
+      const blocked = await run(STOP_HOOK, ["--scope", "api"], { cwd: s.dir, stdin });
+      assertHas(blocked.out, '"decision":"block"');
+    }
+  } finally { s.cleanup(); }
+});
+
 test("hook: no gate files anywhere means silence", async () => {
   const s = sandbox();
   try {


### PR DESCRIPTION
## The failure

The six-block release exists so the hook never traps an agent that cannot finish. It compared a hash of the ledger bytes between stops:

```js
const contentHash = sha256(combined + invalid.join("\0")).slice(0, 24);
```

Any edit resets the counter to zero. A comment, a reflowed line, a reworded `CHECK:`, or the checker itself replacing an evidence line with a fresh `PATH` hash and output tail all count as progress.

That inverts the guard. An agent that stops without touching anything is released after six blocks. An agent that keeps editing the ledger without meeting a gate rearms the counter every turn and is never released by unlazy at all, so only Claude Code's own consecutive-stop limit ends it. The second case is the one the guard was written for.

Reproduced with six blocked stops followed by one cosmetic edit:

```text
stop 1..6   {"decision":"block", ...}
            append "<!-- still thinking about it -->"
stop 7      {"decision":"block", ...}      expected: releasing after 6 blocks
```

The evidence-rewrite path makes this reachable without any authoring mistake: running the checker between stops is enough to rearm the guard.

## The contract after the change

Progress means a change in resolved gate state, not in bytes. The hook already computes that state to decide whether to block, so the hash now covers the qualified id and state of every gate, plus one invalid marker per unparseable ledger:

```js
const progressHash = sha256(resolved.sort().join("\0")).slice(0, 24);
```

Parse diagnostics are deliberately excluded from the hash. They carry line numbers that shift on an unrelated edit, which would restore byte coupling through the back door, so an unparseable ledger contributes only `<file>:PARSE=invalid`.

A gate becoming met, unmet, or abandoned still rearms the guard, and so does a ledger becoming valid or invalid. Editing without changing any of those does not. Nothing else about the hook changes: same block decision, same session and scope keying, same `MAX_BLOCKS`.

`SKILL.md` now says what progress means rather than leaving it to the reader.

## Regression evidence

Two tests in `tests/run-tests.mjs`, one for each direction, because a fix that simply stopped resetting would pass the first and fail the second:

- `hook: the loop guard tracks gate state, not file bytes` - six blocks, cosmetic edit, then the release must fire.
- `hook: meeting a gate resets the loop guard` - three blocks, meet a gate, then four more stops must still block.

Before the patch:

```text
FAIL hook: the loop guard tracks gate state, not file bytes
     output missing "releasing after 6 blocks"
ok   hook: meeting a gate resets the loop guard
1/2 passed
```

After, with the full suite green:

```text
28/28 passed          run-tests
19/19 passed          hardening-tests
10/10 passed          stress-tests
self-check ok (9/9)
```

The existing `hook: each pipeline keeps its own loop-guard counter` test still passes unchanged, so per-scope and per-session isolation is unaffected.

## Notes

No new dependency, Node 16 stdlib only, no em dash or en dash. The hook still executes nothing and still fails open on state-write failure.
