### PR TITLE
fix: warn when a literal path is silently read as an EXPECT regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This section describes the current source tree. It does not claim that `2.1.0` h
 - Add `--reverify` so parent verification executes already checked runnable gates and removes completion when the oracle no longer passes.
 - Require both process exit `0` and `EXPECT:` match. Include resolved shell, resolved working directory, exit status, and decisive output in evidence and diagnostics.
 - Discard an in-flight result when the gate's bound oracle changes before writeback.
+- Warn when a slash-wrapped `EXPECT:` containing an unescaped inner slash is read as a regular expression. A literal path silently became a pattern whose dots matched any character, and the wrapping slashes leave no way to express the literal.
 
 ### Command trust and portability
 

--- a/references/gates.md
+++ b/references/gates.md
@@ -40,6 +40,7 @@ The fenced example above is documentation. Lines inside fenced code blocks are i
 - Write `ABANDON: <id> <reason>` only for a gate in the same file. The reason must contain non-whitespace text. An unknown id is warned and resolves no live gate.
 - Do not define a ledger with zero gates. A named empty or malformed ledger is a parse error, not `ALL MET`.
 - Use `/pattern/flags` for a JavaScript regular-expression expectation or plain text for a substring. An invalid regular expression is a parse error.
+- Remember that the wrapping slashes always win. `EXPECT: /etc/app/conf/` is the pattern `etc/app/conf`, not that literal path, so its dots match any character. An unescaped inner slash is warned because both readings are plausible. Escape the inner slashes to keep the pattern, or drop the wrapping slashes and match a distinctive substring such as `etc/app/conf`.
 
 Ids are unique within one file. Tools qualify them with the file stem in tree-wide output, such as `leaf-1.2.1:G3` or `node-1.1:N2`. Use the qualified form in reports and handoffs.
 

--- a/scripts/lib/gates.mjs
+++ b/scripts/lib/gates.mjs
@@ -49,6 +49,9 @@ const ABANDON_RE = /^ABANDON:\s*(\S*)\s*(.*)$/;
 const OWNS_RE = /^OWNS:\s*(.*)$/;
 const FENCE_OPEN_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
 const REGEX_RE = /^\/([\s\S]*)\/([a-z]*)$/;
+// A pattern author escapes an inner slash or has none. A literal path always
+// carries one, so an unescaped inner slash marks the ambiguous reading.
+const UNESCAPED_SLASH_RE = /(^|[^\\])\//;
 const SCOPE_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
 function parseRegex(expect) {
@@ -62,7 +65,12 @@ function parseRegex(expect) {
   } catch (error) {
     return { error: "invalid EXPECT regex: " + error.message };
   }
-  return { kind: "regex", source: match[1], flags: match[2] };
+  return {
+    kind: "regex",
+    source: match[1],
+    flags: match[2],
+    pathLike: UNESCAPED_SLASH_RE.test(match[1]),
+  };
 }
 
 // The checker and Stop hook both consume this exact result. Diagnostics are
@@ -202,6 +210,14 @@ export function parseGates(text, options = {}) {
     if (hasExpect) {
       const parsed = parseRegex(gate.expect);
       if (parsed.error) errors.push("gate " + gate.id + ": " + parsed.error);
+      else if (parsed.pathLike) {
+        // Warn rather than reject: the pattern reading may be intended, and a
+        // literal path cannot be expressed once the wrapping slashes sniff.
+        warnings.push("gate " + gate.id + ": EXPECT " + JSON.stringify(gate.expect) +
+          " is read as a regular expression, so its dots and other metacharacters" +
+          " are wildcards. Escape the inner slashes to keep the pattern, or drop" +
+          " the wrapping slashes to match a literal substring.");
+      }
       gate.expectation = parsed;
     } else gate.expectation = null;
   }

--- a/tests/hardening-tests.mjs
+++ b/tests/hardening-tests.mjs
@@ -444,6 +444,32 @@ test("leases: unsafe declarations, unknown leaves, and wildcard witnesses fail c
   } finally { s.cleanup(); }
 });
 
+test("parser: a slash wrapped literal path warns that it became a regex", async () => {
+  const s = sandbox();
+  try {
+    // "/etc/app/conf/" is a plausible literal expectation, and the slash sniff
+    // silently turns it into the pattern etc/app/conf, whose dots would be
+    // wildcards. There is no way to express that literal, so the author needs
+    // to be told which reading applies.
+    s.write("show.mjs", "console.log('resolved /etc/app/conf/');\n");
+    s.write("GATES.md", gate("G1", "config path is reported", "node show.mjs", "/etc/app/conf/"));
+    const warned = await gateRun(s, ["--status"], { approve: false });
+    has(warned.out, "G1");
+    has(warned.out, "read as a regular expression");
+    assert(warned.code === 1, "a warning must not become a parse error, got " + warned.code);
+
+    // A deliberate pattern carries no unescaped inner slash and stays quiet.
+    s.write("GATES.md", gate("G2", "typecheck is clean", "node show.mjs", "/Found 0 errors/"));
+    const quiet = await gateRun(s, ["--status"], { approve: false });
+    lacks(quiet.out, "read as a regular expression");
+
+    // Escaping keeps the pattern reading without the warning.
+    s.write("GATES.md", gate("G3", "path pattern", "node show.mjs", "/etc\\/app/"));
+    const escaped = await gateRun(s, ["--status"], { approve: false });
+    lacks(escaped.out, "read as a regular expression");
+  } finally { s.cleanup(); }
+});
+
 let passed = 0;
 const failures = [];
 for (const item of tests) {


### PR DESCRIPTION
## The failure

A slash-wrapped `EXPECT:` is compiled as a regular expression. That is correct for a pattern and wrong for a path, and the sniff cannot tell them apart.

`EXPECT: /etc/app/conf/` becomes the pattern `etc/app/conf`. Every dot is now a wildcard, so the expectation accepts output it should reject. Because the wrapping slashes always win, there is also no way to write that path as a literal.

Demonstrated with a divergence case where the two readings disagree:

```markdown
- [ ] S1: literal or regex?
  CHECK: node -e "console.log('abc')"
  EXPECT: /a.c/
  EVIDENCE: pending
```

```text
  PASS S1: literal or regex?
ALL MET (1 met)
```

A literal `/a.c/` never appears in that output. The gate passes only because the expectation was silently reinterpreted.

A weakened expectation is the failure mode this project cares most about. The gate passes, the evidence looks decisive, exit `0` and `EXPECT:` both hold, and the ledger certifies completion. Nothing in the current diagnostics mentions that the expectation is not what the author wrote. `references/gates.md` documented the `/pattern/flags` syntax but never that it takes precedence over a literal reading.

## The contract after the change

Warn, do not reject. The pattern reading is often intended, and an error would break valid ledgers that already rely on it.

The tell is an unescaped inner slash. A deliberate pattern escapes it or has none; a path always carries one:

| EXPECT | reading | diagnostic |
| --- | --- | --- |
| `/Found 0 errors/` | pattern | quiet |
| `/etc\/app/` | pattern, escaped | quiet |
| `/etc/app/conf/` | pattern, probably meant as a path | warned |

```text
gate-check: GATES.md: warning gate G1: EXPECT "/etc/app/conf/" is read as a
regular expression, so its dots and other metacharacters are wildcards. Escape
the inner slashes to keep the pattern, or drop the wrapping slashes to match a
literal substring.
```

The message names both fixes, because the second one is not obvious: dropping the wrapping slashes and matching `etc/app/conf` as a substring is the only way to get a literal reading.

Parsing and matching are otherwise unchanged. This adds one warning on the ambiguous form and nothing else, so no gate changes state because of this patch.

## Regression evidence

`tests/hardening-tests.mjs`: `parser: a slash wrapped literal path warns that it became a regex`. It covers the warning, both quiet cases, and asserts exit `1` rather than `2` so a warning cannot escalate into a parse error.

Fails before the patch, passes after, with the full suite green:

```text
26/26 passed          run-tests
20/20 passed          hardening-tests
10/10 passed          stress-tests
self-check ok (9/9)
```

## Notes

Warnings already print through the existing `doc.warnings` path in `gate-check.mjs`, so this needed no new reporting surface. No new dependency, Node 16 stdlib only, no em dash or en dash.
